### PR TITLE
Investigate github issue root cause

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,8 @@ module.exports = defineConfig({
         paletteMaker: resolve(__dirname, 'apps/palette-maker/index.html'),
         qr: resolve(__dirname, 'apps/qr-code-generator/index.html'),
         browserDiagnostic: resolve(__dirname, 'apps/browser-diagnostic/index.html'),
-        romanNumeralTranslator: resolve(__dirname, 'apps/roman-numeral-translator/index.html')
+        romanNumeralTranslator: resolve(__dirname, 'apps/roman-numeral-translator/index.html'),
+        reverseEngineeringLab: resolve(__dirname, 'apps/reverse-engineering-lab/index.html')
       }
     }
   },


### PR DESCRIPTION
Add `reverse-engineering-lab` to the Vite build configuration to fix its 404 error on GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-86abf027-d4e1-4863-a304-a1cdebc1533f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86abf027-d4e1-4863-a304-a1cdebc1533f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

