### PR TITLE
Fix quick diff app 404 error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,8 @@ module.exports = defineConfig({
         qr: resolve(__dirname, 'apps/qr-code-generator/index.html'),
         browserDiagnostic: resolve(__dirname, 'apps/browser-diagnostic/index.html'),
         romanNumeralTranslator: resolve(__dirname, 'apps/roman-numeral-translator/index.html'),
-        reverseEngineeringLab: resolve(__dirname, 'apps/reverse-engineering-lab/index.html')
+        reverseEngineeringLab: resolve(__dirname, 'apps/reverse-engineering-lab/index.html'),
+        quickDiff: resolve(__dirname, 'apps/quick-diff/index.html')
       }
     }
   },


### PR DESCRIPTION
Add quickDiff entry to Vite build config to resolve 404 for quick-diff app.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6aa7332-3816-48c5-a08d-311626f96ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6aa7332-3816-48c5-a08d-311626f96ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

