### PR TITLE
Fix preview build deployment bug

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,23 +2,22 @@ name: PR Preview Build
 
 on:
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages-preview-${{ github.ref }}
+concurrency: 
+  group: preview-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  build:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  deploy-preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -29,22 +28,15 @@ jobs:
         with:
           node-version: 20
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
       - name: Install dependencies
         run: npm ci
 
       - name: Build static site
-        run: npm run build -- --outDir website
+        run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          path: website
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        with:
-          preview: true
+          source-dir: ./dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview


### PR DESCRIPTION
Replace the PR preview workflow to deploy to a separate URL for testing instead of overwriting the main website.

The previous setup using `actions/deploy-pages@v4` with `preview: true` did not create a distinct preview URL, leading to unapproved changes being deployed to the production site. This PR switches to `rossjrw/pr-preview-action@v1` to ensure previews are deployed to unique subdirectories based on the PR number, preventing conflicts with the main site.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0f20e2e-4c28-4f7f-9a4e-c4f39a240c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0f20e2e-4c28-4f7f-9a4e-c4f39a240c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

