### PR TITLE
Add gad_campaignid to tracker remover

### DIFF
--- a/src/apps/clean-url-tracker-remover/main.js
+++ b/src/apps/clean-url-tracker-remover/main.js
@@ -455,7 +455,8 @@ const TRACKER_EXACT = new Set(
     'hsCtaTracking',
     'ml_subscriber',
     'ml_subscriber_hash',
-    'rb_clickid'
+    'rb_clickid',
+    'gad_campaignid'
   ].map((key) => key.toLowerCase())
 );
 
@@ -475,10 +476,11 @@ const TRACKER_PREFIXES = [
   'vero_',
   'aff_',
   'sscid',
-  'rb_'
+  'rb_',
+  'gad_'
 ];
 
-const TRACKER_SUFFIXES = ['_cid', '_source', '_medium', '_campaign', '_term', '_content', '_id', '_name'];
+const TRACKER_SUFFIXES = ['_cid', '_source', '_medium', '_campaign', '_term', '_content', '_id', '_name', '_campaignid'];
 
 const TRACKER_REGEX = [
   /^utm[\w-]*$/,


### PR DESCRIPTION
Extend URL cleaner to remove `gad_campaignid` and other Google Ads-style tracking parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-c863f637-a395-4535-9ece-1b8c8c26767a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c863f637-a395-4535-9ece-1b8c8c26767a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

