### PR TITLE
Add Markdown Repair tool

### DIFF
--- a/apps/markdown-repair/index.html
+++ b/apps/markdown-repair/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Markdown Repair</title>
+    <meta
+      name="description"
+      content="Repair and reformat markdown documents: fix line breaks, bullets, tables, trailing spaces, and other common formatting issues."
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/apps/markdown-repair/main.js"></script>
+  </body>
+</html>

--- a/src/apps/markdown-repair/main.js
+++ b/src/apps/markdown-repair/main.js
@@ -1,0 +1,213 @@
+import { createAppShell } from '../shared/appShell.js';
+import { repairMarkdown } from './repair.js';
+import './styles.css';
+
+const ACCENT = '#6ee7b7';
+
+const { body } = createAppShell({
+  title: 'Markdown Repair',
+  description:
+    'Repair and reformat markdown documents: fix line breaks in sentences, soft hyphens, broken bullets, tables, trailing spaces, and extra line breaks.',
+  accent: ACCENT
+});
+
+const layout = document.createElement('div');
+layout.className = 'mdr-layout';
+
+const editorCard = document.createElement('section');
+editorCard.className = 'mdr-card';
+
+const editorHeader = document.createElement('header');
+editorHeader.className = 'mdr-card-header';
+editorHeader.innerHTML = `
+  <div>
+    <h2>Markdown input</h2>
+    <p>Paste or type markdown. Code blocks are preserved; paragraphs, lists, and tables are repaired.</p>
+  </div>
+`;
+
+const actionBar = document.createElement('div');
+actionBar.className = 'mdr-action-bar';
+
+const pasteBtn = createButton('Paste from clipboard', 'primary');
+const repairBtn = createButton('Repair all', 'primary');
+const copyBtn = createButton('Copy result');
+const clearBtn = createButton('Clear');
+
+actionBar.append(pasteBtn, repairBtn, copyBtn, clearBtn);
+
+const textareaLabel = document.createElement('label');
+textareaLabel.className = 'mdr-field-label';
+textareaLabel.textContent = 'Markdown';
+textareaLabel.setAttribute('for', 'mdr-textarea');
+
+const textarea = document.createElement('textarea');
+textarea.id = 'mdr-textarea';
+textarea.className = 'mdr-textarea';
+textarea.placeholder = 'Paste markdown here…\n\nExample:\nThis is a sen-\ntence that was broken.\n\n- Bullet one\n- Bullet two';
+textarea.autocapitalize = 'off';
+textarea.autocomplete = 'off';
+textarea.spellcheck = false;
+textarea.rows = 14;
+
+const metaBar = document.createElement('footer');
+metaBar.className = 'mdr-meta';
+metaBar.innerHTML = `
+  <span class="mdr-stat"><strong data-role="chars">0</strong> chars</span>
+  <span class="mdr-stat"><strong data-role="lines">0</strong> lines</span>
+`;
+
+const charsEl = metaBar.querySelector('[data-role="chars"]');
+const linesEl = metaBar.querySelector('[data-role="lines"]');
+
+editorCard.append(editorHeader, actionBar, textareaLabel, textarea, metaBar);
+
+const optionsCard = document.createElement('section');
+optionsCard.className = 'mdr-card';
+
+const optionsHeader = document.createElement('header');
+optionsHeader.className = 'mdr-card-header';
+optionsHeader.innerHTML = `
+  <div>
+    <h2>Repair options</h2>
+    <p>Toggle individual repairs. All are on by default.</p>
+  </div>
+`;
+
+const optionsGrid = document.createElement('div');
+optionsGrid.className = 'mdr-options-grid';
+
+const options = [
+  { id: 'trimSpaces', label: 'Trim leading/trailing spaces', default: true },
+  { id: 'removeExtraLinebreaks', label: 'Remove extra line breaks (3+ → 2)', default: true },
+  { id: 'fixSoftHyphens', label: 'Fix soft hyphens at line end', default: true },
+  { id: 'fixMidSentenceBreaks', label: 'Join mid-sentence line breaks', default: true },
+  { id: 'fixBrokenBullets', label: 'Fix broken bullet lists', default: true },
+  { id: 'formatTables', label: 'Format tables (align columns)', default: true }
+];
+
+const optionCheckboxes = {};
+options.forEach((opt) => {
+  const label = document.createElement('label');
+  label.className = 'mdr-option';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = opt.default;
+  cb.id = `mdr-opt-${opt.id}`;
+  cb.dataset.opt = opt.id;
+  optionCheckboxes[opt.id] = cb;
+  label.appendChild(cb);
+  label.appendChild(document.createTextNode(' ' + opt.label));
+  optionsGrid.appendChild(label);
+});
+
+optionsCard.append(optionsHeader, optionsGrid);
+
+const status = document.createElement('div');
+status.className = 'mdr-status';
+status.setAttribute('role', 'status');
+status.setAttribute('aria-live', 'polite');
+
+layout.append(editorCard, optionsCard, status);
+body.appendChild(layout);
+
+const state = { toastTimer: null };
+
+textarea.addEventListener('input', updateStats);
+
+pasteBtn.addEventListener('click', async () => {
+  const clipboardText = await readClipboardText();
+  if (clipboardText != null) {
+    textarea.value = clipboardText;
+    updateStats();
+    showStatus('Pasted from clipboard.');
+  }
+  textarea.focus();
+});
+
+repairBtn.addEventListener('click', () => {
+  const current = textarea.value;
+  if (!current) {
+    showStatus('Nothing to repair—paste some markdown first.', true);
+    return;
+  }
+  const opts = {};
+  options.forEach((opt) => {
+    opts[opt.id] = optionCheckboxes[opt.id].checked;
+  });
+  const repaired = repairMarkdown(current, opts);
+  textarea.value = repaired;
+  updateStats();
+  showStatus('Repairs applied.');
+  textarea.focus();
+});
+
+copyBtn.addEventListener('click', async () => {
+  const ok = await writeClipboardText(textarea.value);
+  if (ok) showStatus('Copied to clipboard.');
+});
+
+clearBtn.addEventListener('click', () => {
+  if (!textarea.value) return;
+  textarea.value = '';
+  updateStats();
+  showStatus('Cleared.');
+  textarea.focus();
+});
+
+updateStats();
+
+if (!navigator.clipboard) {
+  showStatus('Clipboard APIs are not available. You can still paste manually (Ctrl/⌘+V).', true);
+}
+
+function updateStats() {
+  const text = textarea.value ?? '';
+  charsEl.textContent = new Intl.NumberFormat().format(Array.from(text).length);
+  linesEl.textContent = new Intl.NumberFormat().format(text.split(/\r\n|\r|\n/).length);
+}
+
+function showStatus(message, isError = false) {
+  status.textContent = message;
+  status.dataset.state = isError ? 'error' : 'ok';
+  status.classList.add('visible');
+  if (state.toastTimer) clearTimeout(state.toastTimer);
+  state.toastTimer = setTimeout(() => status.classList.remove('visible'), 2600);
+}
+
+function createButton(label, variant) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = variant === 'primary' ? 'mdr-btn primary' : 'mdr-btn';
+  btn.textContent = label;
+  return btn;
+}
+
+async function readClipboardText() {
+  if (!navigator.clipboard?.readText) {
+    showStatus('Clipboard read is not supported. Paste manually instead.', true);
+    return null;
+  }
+  try {
+    return await navigator.clipboard.readText();
+  } catch (err) {
+    console.error(err);
+    showStatus('Could not read clipboard.', true);
+    return null;
+  }
+}
+
+async function writeClipboardText(text) {
+  if (!navigator.clipboard?.writeText) {
+    showStatus('Clipboard write is not supported.', true);
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    console.error(err);
+    showStatus('Could not write to clipboard.', true);
+    return false;
+  }
+}

--- a/src/apps/markdown-repair/repair.js
+++ b/src/apps/markdown-repair/repair.js
@@ -1,0 +1,342 @@
+/**
+ * Markdown repair and reformatting utilities.
+ * Preserves code blocks, tables, and list structure while fixing common issues.
+ */
+
+const BLOCK_FENCE = /^(`{3,}|~{3,})/;
+const TABLE_ROW = /^\|.+\|$/;
+const LIST_ITEM = /^(\s*)([-*+]|\d+\.)\s/;
+const HEADER = /^#{1,6}\s/;
+const BLOCKQUOTE = /^\s*>/;
+const HR = /^(\s*[-*_]\s*){3,}$/;
+
+/**
+ * Repair markdown document with all fixes.
+ * @param {string} text - Raw markdown
+ * @param {Object} options - Repair options
+ * @returns {string} Repaired markdown
+ */
+export function repairMarkdown(text, options = {}) {
+  if (!text || typeof text !== 'string') return text;
+
+  const opts = {
+    trimSpaces: true,
+    removeExtraLinebreaks: true,
+    fixMidSentenceBreaks: true,
+    fixSoftHyphens: true,
+    fixBrokenBullets: true,
+    formatTables: true,
+    ...options
+  };
+
+  let result = text;
+
+  // Preserve fenced code blocks and process the rest
+  const parts = splitByFencedBlocks(result);
+  result = parts
+    .map((part, i) => {
+      if (part.isCode) return part.raw;
+      return repairMarkdownSection(part.text, opts);
+    })
+    .join('\n')
+    .replace(/\n\n+/g, '\n\n');
+
+  return result;
+}
+
+function splitByFencedBlocks(text) {
+  const parts = [];
+  const lines = text.split(/\r\n|\r|\n/);
+  let i = 0;
+  let current = [];
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const fenceMatch = line.match(/^([ \t]*)(`{3,}|~{3,})([^\n]*)$/);
+
+    if (fenceMatch && current.length === 0) {
+      const fence = fenceMatch[2];
+      const block = [line];
+      i++;
+      while (i < lines.length) {
+        const closeMatch = lines[i].match(new RegExp(`^([ \\t]*)(${fence.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})\\s*$`));
+        block.push(lines[i]);
+        if (closeMatch) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      parts.push({ isCode: true, raw: block.join('\n') });
+    } else if (fenceMatch && current.length > 0) {
+      parts.push({ isCode: false, text: current.join('\n') });
+      current = [];
+      // Reprocess this line as fence start (don't increment i)
+    } else {
+      current.push(line);
+      i++;
+    }
+  }
+
+  if (current.length > 0) {
+    parts.push({ isCode: false, text: current.join('\n') });
+  }
+
+  return parts;
+}
+
+function repairMarkdownSection(text, opts) {
+  let lines = text.split(/\r\n|\r|\n/);
+
+  if (opts.trimSpaces) {
+    lines = lines.map((line) => line.replace(/[ \t]+$/, ''));
+  }
+
+  if (opts.fixSoftHyphens) {
+    lines = fixSoftHyphens(lines);
+  }
+
+  if (opts.fixMidSentenceBreaks) {
+    lines = fixMidSentenceBreaks(lines);
+  }
+
+  if (opts.fixBrokenBullets) {
+    lines = fixBrokenBullets(lines);
+  }
+
+  if (opts.formatTables) {
+    lines = formatTables(lines);
+  }
+
+  let result = lines.join('\n');
+
+  if (opts.removeExtraLinebreaks) {
+    result = result.replace(/\n{3,}/g, '\n\n');
+  }
+
+  return result;
+}
+
+/** Remove soft hyphens at end of line and join with next word */
+function fixSoftHyphens(lines) {
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const next = lines[i + 1];
+    const trimmed = line.replace(/\s+$/, '');
+    const endsWithHyphen = /-\s*$/.test(trimmed) && trimmed.length > 1;
+    const nextStartsWord = next && /^[a-zA-Z0-9]/.test(next.trim());
+
+    if (endsWithHyphen && nextStartsWord && !isBlockStart(next)) {
+      out.push(trimmed.replace(/\s*-\s*$/, '') + next.trim());
+      i++;
+    } else {
+      out.push(line);
+    }
+  }
+  return out;
+}
+
+/** Join lines that break mid-sentence (in paragraph context) */
+function fixMidSentenceBreaks(lines) {
+  const out = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const next = lines[i + 1];
+
+    const isBlank = /^\s*$/.test(line);
+    const isBlockStartLine = isBlockStart(line);
+    const nextIsBlockStart = next && isBlockStart(next);
+    const nextIsBlank = next && /^\s*$/.test(next);
+
+    const endsSentence = /[.!?:]\s*$/.test(line) || /["')\]]\s*$/.test(line);
+    const endsWithCommaOrColon = /[,\u2013\u2014:;]\s*$/.test(line);
+    const startsWithLower = next && /^[a-z\u00e0-\u024f]/.test(next.trim());
+    const lineEndsWithoutPeriod = line.trim().length > 0 && !endsSentence && !endsWithCommaOrColon;
+    const lineEndsWithLetter = /[a-z\u00e0-\u024f]\s*$/i.test(line);
+
+    const shouldJoin =
+      !isBlank &&
+      !isBlockStartLine &&
+      !nextIsBlockStart &&
+      !nextIsBlank &&
+      next &&
+      lineEndsWithLetter &&
+      (endsWithCommaOrColon || lineEndsWithoutPeriod) &&
+      (startsWithLower || /^\d/.test(next.trim()));
+
+    if (shouldJoin) {
+      const joined = line.trimEnd() + ' ' + next.trim();
+      out.push(joined);
+      i += 2;
+    } else {
+      out.push(line);
+      i++;
+    }
+  }
+  return out;
+}
+
+function isBlockStart(line) {
+  const t = line.trim();
+  return (
+    BLOCK_FENCE.test(t) ||
+    HEADER.test(t) ||
+    BLOCKQUOTE.test(t) ||
+    LIST_ITEM.test(t) ||
+    TABLE_ROW.test(t) ||
+    HR.test(t) ||
+    t === '---' ||
+    t === '***' ||
+    t === '___'
+  );
+}
+
+/** Fix bullet lists: normalize markers, fix indentation, merge orphan lines */
+function fixBrokenBullets(lines) {
+  const out = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const next = lines[i + 1];
+
+    const listMatch = line.match(LIST_ITEM);
+    const nextListMatch = next && next.match(LIST_ITEM);
+    const nextBlank = next && /^\s*$/.test(next);
+    const nextIndent = next && /^\s+/.test(next) && !nextListMatch;
+
+    if (listMatch && next && !nextBlank && !nextListMatch && nextIndent) {
+      const indent = next.match(/^(\s+)/)[1];
+      const bulletIndent = listMatch[1].length;
+      if (indent.length > bulletIndent) {
+        out.push(line);
+        out.push(next.trimStart());
+        i += 2;
+        continue;
+      }
+    }
+
+    if (listMatch && next && !nextBlank && !nextListMatch && !nextIndent && !isBlockStart(next)) {
+      const content = next.trim();
+      if (content.length > 0 && !content.startsWith('-') && !content.startsWith('*') && !/^\d+\./.test(content)) {
+        out.push(line.trimEnd() + ' ' + content);
+        i += 2;
+        continue;
+      }
+    }
+
+    if (listMatch) {
+      const normalized = line.replace(/^(\s*)([-*+])\s+/, (_, sp, m) => sp + '- ');
+      out.push(normalized);
+    } else {
+      out.push(line);
+    }
+    i++;
+  }
+  return out;
+}
+
+/** Format markdown tables: align columns, fix separators */
+function formatTables(lines) {
+  const out = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!TABLE_ROW.test(line.trim())) {
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    const tableLines = [];
+    while (i < lines.length && TABLE_ROW.test(lines[i].trim())) {
+      tableLines.push(lines[i]);
+      i++;
+    }
+
+    const formatted = formatTableBlock(tableLines);
+    out.push(...formatted);
+  }
+  return out;
+}
+
+function formatTableBlock(rows) {
+  if (rows.length === 0) return rows;
+
+  const parseRow = (row) => {
+    const trimmed = row.trim();
+    const cells = trimmed
+      .slice(1, -1)
+      .split(/\|/)
+      .map((c) => c.trim());
+    return cells;
+  };
+
+  const parsed = rows.map(parseRow);
+  const numCols = Math.max(...parsed.map((r) => r.length));
+
+  for (const row of parsed) {
+    while (row.length < numCols) row.push('');
+  }
+
+  const isSeparator = (row) => {
+    const str = row.join(' ').replace(/\s/g, '');
+    return /^[-:]+$/.test(str) || row.every((c) => /^[-:\s]+$/.test(c));
+  };
+
+  let headerEnd = 0;
+  for (let j = 0; j < parsed.length; j++) {
+    if (isSeparator(parsed[j])) {
+      headerEnd = j;
+      break;
+    }
+    headerEnd = j + 1;
+  }
+
+  const colWidths = [];
+  for (let c = 0; c < numCols; c++) {
+    let max = 3;
+    for (let r = 0; r < parsed.length; r++) {
+      if (r === headerEnd && isSeparator(parsed[headerEnd])) continue;
+      const len = parsed[r][c]?.length ?? 0;
+      if (len > max) max = len;
+    }
+    colWidths.push(max);
+  }
+
+  const pad = (s, w, align = 'left') => {
+    const len = (s ?? '').length;
+    if (align === 'right') return ' '.repeat(Math.max(0, w - len)) + (s ?? '');
+    if (align === 'center') {
+      const padLeft = Math.floor((w - len) / 2);
+      const padRight = w - len - padLeft;
+      return ' '.repeat(Math.max(0, padLeft)) + (s ?? '') + ' '.repeat(Math.max(0, padRight));
+    }
+    return (s ?? '') + ' '.repeat(Math.max(0, w - len));
+  };
+
+  const formatCell = (cell, c, r) => {
+    const w = colWidths[c];
+    if (r === headerEnd && isSeparator(parsed[r])) {
+      const content = cell.replace(/\s/g, '');
+      const left = content.startsWith(':');
+      const right = content.endsWith(':');
+      if (left && right) return ':' + '-'.repeat(Math.max(0, w - 2)) + ':';
+      if (right) return '-'.repeat(Math.max(0, w - 1)) + ':';
+      if (left) return ':' + '-'.repeat(Math.max(0, w - 1));
+      return '-'.repeat(w);
+    }
+    return pad(cell, w);
+  };
+
+  const result = [];
+  for (let r = 0; r < parsed.length; r++) {
+    const cells = parsed[r].map((cell, c) => formatCell(cell, c, r));
+    result.push('| ' + cells.join(' | ') + ' |');
+  }
+  return result;
+}

--- a/src/apps/markdown-repair/styles.css
+++ b/src/apps/markdown-repair/styles.css
@@ -1,0 +1,177 @@
+.mdr-layout {
+  display: grid;
+  gap: 22px;
+}
+
+.mdr-card {
+  position: relative;
+  display: grid;
+  gap: 18px;
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: 26px;
+  background: rgba(11, 14, 27, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 25px 45px rgba(6, 7, 13, 0.55);
+  overflow: hidden;
+}
+
+.mdr-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 10% -15%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 60%);
+  opacity: 0.55;
+}
+
+.mdr-card-header {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 8px;
+}
+
+.mdr-card-header h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 3vw, 1.65rem);
+  letter-spacing: -0.01em;
+}
+
+.mdr-card-header p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.mdr-action-bar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.mdr-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.92);
+  padding: 10px 16px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease, background 150ms ease;
+}
+
+.mdr-btn.primary {
+  background: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.06));
+  border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.22));
+}
+
+.mdr-btn:hover,
+.mdr-btn:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22));
+  background: color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
+}
+
+.mdr-field-label {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.mdr-textarea {
+  position: relative;
+  z-index: 1;
+  min-height: clamp(280px, 35vh, 420px);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(3, 5, 15, 0.84);
+  padding: 16px 18px;
+  color: rgba(255, 255, 255, 0.94);
+  font-size: clamp(0.9rem, 1.6vw, 1rem);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.mdr-textarea:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.24));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.mdr-meta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.mdr-stat strong {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.mdr-options-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.mdr-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.92rem;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.mdr-option input {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.mdr-status {
+  justify-self: stretch;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.mdr-status.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.mdr-status[data-state='error'] {
+  color: #ffb8c3;
+  border-color: rgba(255, 81, 134, 0.45);
+}

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -192,6 +192,14 @@ export const apps = [
       accent: '#e07a5f'
     },
     {
+      slug: 'markdown-repair',
+      title: 'Markdown Repair',
+      blurb: 'Repair and reformat markdown: fix line breaks, soft hyphens, broken bullets, tables, trailing spaces, and extra line breaks.',
+      icon: '📝',
+      href: 'apps/markdown-repair/index.html',
+      accent: '#6ee7b7'
+    },
+    {
       slug: 'piano-and-stave',
       title: 'Piano Stave Studio',
       blurb: 'Click a piano, hear each tone, and watch matching notes land on a live treble staff.',

--- a/vite.config.js
+++ b/vite.config.js
@@ -47,7 +47,8 @@ module.exports = defineConfig({
         pianoAndStave: resolve(__dirname, 'apps/piano-and-stave/index.html'),
         slopeInterceptCalculator: resolve(__dirname, 'apps/slope-intercept-calculator/index.html'),
         taskTracker: resolve(__dirname, 'apps/task-tracker/index.html'),
-        pdfForensicAnalysis: resolve(__dirname, 'apps/pdf-forensic-analysis/index.html')
+        pdfForensicAnalysis: resolve(__dirname, 'apps/pdf-forensic-analysis/index.html'),
+        markdownRepair: resolve(__dirname, 'apps/markdown-repair/index.html')
       }
     }
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **Markdown Repair** app that repairs and reformats markdown documents.

## Features

- **Remove line breaks in sentences** – Joins lines that break mid-sentence and fixes soft hyphens at line ends (e.g. `word-\nword` → `wordword`)
- **Fix broken bullets** – Normalizes bullet markers (`*` and `+` → `-`), merges orphan continuation lines into list items
- **Format tables** – Aligns columns and fixes separator rows
- **Trim trailing spaces** – Removes trailing spaces from each line
- **Remove extra line breaks** – Collapses 3+ consecutive newlines to 2
- **Preserve code blocks** – Fenced code blocks (```) are left unchanged during repair

## UI

- Paste from clipboard or type markdown
- "Repair all" applies all enabled fixes
- Toggle individual repair options (all on by default)
- Copy result to clipboard

## Files

- `apps/markdown-repair/index.html` – Entry point
- `src/apps/markdown-repair/main.js` – App shell and UI
- `src/apps/markdown-repair/repair.js` – Repair logic
- `src/apps/markdown-repair/styles.css` – Styles
- Registered in `vite.config.js` and `src/data/apps.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3855ada8-60a4-4161-a6d3-b7cc0259acfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3855ada8-60a4-4161-a6d3-b7cc0259acfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

