### PR TITLE
Site visual refresh: minimal light UI, dense grid, neon accents

### DIFF
--- a/src/apps/apriltag-scout/styles.css
+++ b/src/apps/apriltag-scout/styles.css
@@ -15,7 +15,7 @@
   display: grid;
   gap: clamp(18px, 2.5vw, 26px);
   padding: clamp(22px, 3vw, 32px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -45,7 +45,7 @@
   align-items: center;
   gap: 6px;
   padding: 6px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -73,7 +73,7 @@
 
 .stage-view {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   overflow: hidden;
   background: #f6f6f9;
   border: 1px solid var(--border-soft);
@@ -81,7 +81,7 @@
 }
 
 .stage-view:fullscreen {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   min-height: 100vh;
   width: 100vw;
   height: 100vh;
@@ -146,7 +146,7 @@
 
 .primary-button {
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 12px 24px;
   font-size: 0.95rem;
   font-weight: 600;
@@ -171,7 +171,7 @@
 }
 
 .ghost-button {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 18px;
   border: 1px solid rgba(255, 255, 255, 0.28);
   background: rgba(18, 18, 30, 0.04);
@@ -196,7 +196,7 @@
 }
 
 .family-pill {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 16px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(18, 18, 30, 0.04);
@@ -221,7 +221,7 @@
   display: grid;
   gap: 4px;
   padding: 14px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
 }
@@ -251,7 +251,7 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed rgba(255, 255, 255, 0.2);
   background: rgba(18, 18, 30, 0.04);
   color: var(--text-muted);
@@ -260,7 +260,7 @@
 }
 
 .detection-card {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 18px 20px;
@@ -301,7 +301,7 @@
 }
 
 .chip {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 8px 14px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(18, 18, 30, 0.04);
@@ -311,7 +311,7 @@
 
 .orientation-dial {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px;
@@ -323,7 +323,7 @@
 .orientation-dial .dial-arrow {
   width: 64px;
   height: 64px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 2px solid rgba(255, 255, 255, 0.18);
   position: relative;
 }
@@ -364,7 +364,7 @@
 
 .detection-stats div {
   padding: 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(18, 18, 30, 0.03);
 }

--- a/src/apps/apriltag-scout/styles.css
+++ b/src/apps/apriltag-scout/styles.css
@@ -15,11 +15,11 @@
   display: grid;
   gap: clamp(18px, 2.5vw, 26px);
   padding: clamp(22px, 3vw, 32px);
-  border-radius: 28px;
-  background: rgba(11, 14, 27, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 30px 45px rgba(5, 5, 15, 0.55);
 }
 
@@ -30,7 +30,7 @@
 
 .card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--text);
   line-height: 1.5;
 }
 
@@ -45,12 +45,12 @@
   align-items: center;
   gap: 6px;
   padding: 6px 14px;
-  border-radius: 999px;
+  border-radius: 0;
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.03em;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.05);
 }
 
 .status-chip[data-tone='info'] {
@@ -73,10 +73,10 @@
 
 .stage-view {
   position: relative;
-  border-radius: 26px;
+  border-radius: 0;
   overflow: hidden;
-  background: rgba(6, 8, 18, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #f6f6f9;
+  border: 1px solid var(--border-soft);
   min-height: clamp(220px, 40vh, 420px);
 }
 
@@ -120,7 +120,7 @@
   justify-content: center;
   text-align: center;
   padding: 32px;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
   font-weight: 600;
   background: linear-gradient(180deg, rgba(5, 7, 15, 0.65), rgba(5, 7, 15, 0.85));
   transition: opacity 200ms ease;
@@ -146,7 +146,7 @@
 
 .primary-button {
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 12px 24px;
   font-size: 0.95rem;
   font-weight: 600;
@@ -171,11 +171,11 @@
 }
 
 .ghost-button {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 10px 18px;
   border: 1px solid rgba(255, 255, 255, 0.28);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.85);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text);
   font-size: 0.9rem;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -185,7 +185,7 @@
 
 .ghost-button:hover,
 .ghost-button:focus-visible {
-  border-color: rgba(255, 255, 255, 0.6);
+  border-color: var(--text-muted);
   color: #fff;
 }
 
@@ -196,18 +196,18 @@
 }
 
 .family-pill {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 10px 16px;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(18, 18, 30, 0.04);
   font-size: 0.9rem;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .family-pill strong {
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   margin-right: 6px;
 }
 
@@ -221,9 +221,9 @@
   display: grid;
   gap: 4px;
   padding: 14px 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(4, 6, 12, 0.85);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
 }
 
 .metric p {
@@ -231,12 +231,12 @@
   font-size: 0.8rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .metric strong {
   font-size: 1.3rem;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
 }
 
 .detection-list {
@@ -251,18 +251,18 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 20px;
+  border-radius: 0;
   border: 1px dashed rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.7);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text-muted);
   text-align: center;
   display: none;
 }
 
 .detection-card {
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(5, 6, 16, 0.92);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 18px 20px;
   display: grid;
   gap: 14px;
@@ -274,7 +274,7 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: radial-gradient(circle at 105% -10%, color-mix(in srgb, var(--tag-color, var(--accent)) 55%, transparent) 0%, transparent 55%);
+  background: transparent;
   opacity: 0.55;
   pointer-events: none;
 }
@@ -292,7 +292,7 @@
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .detection-card h3 {
@@ -301,19 +301,19 @@
 }
 
 .chip {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 8px 14px;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(18, 18, 30, 0.04);
   font-size: 0.88rem;
   font-weight: 600;
 }
 
 .orientation-dial {
   position: relative;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(2, 4, 10, 0.9);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px;
   display: grid;
   place-items: center;
@@ -323,7 +323,7 @@
 .orientation-dial .dial-arrow {
   width: 64px;
   height: 64px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 2px solid rgba(255, 255, 255, 0.18);
   position: relative;
 }
@@ -351,7 +351,7 @@
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .detection-stats {
@@ -364,9 +364,9 @@
 
 .detection-stats div {
   padding: 12px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  background: rgba(18, 18, 30, 0.03);
 }
 
 .detection-stats dt {
@@ -374,20 +374,20 @@
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .detection-stats dd {
   margin: 4px 0 0;
   font-size: 1rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
 }
 
 .attribution {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .attribution a {

--- a/src/apps/audio-spectrum-analyser/styles.css
+++ b/src/apps/audio-spectrum-analyser/styles.css
@@ -1,7 +1,7 @@
 :root {
   --spec-panel: #f6f6f9;
   --spec-border: var(--border-soft);
-  --spec-muted: rgba(247, 245, 255, 0.65);
+  --spec-muted: rgba(20, 20, 26, 0.55);
 }
 
 .spectrum-app {
@@ -34,9 +34,9 @@
   font: inherit;
   font-size: 0.9rem;
   padding: 8px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--spec-border);
-  background: rgba(0, 0, 0, 0.35);
+  background: #ffffff;
   color: var(--text);
   min-width: 0;
 }
@@ -51,7 +51,7 @@
   font-size: 0.9rem;
   font-weight: 600;
   padding: 10px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   cursor: pointer;
   border: 1px solid transparent;
   transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
@@ -59,7 +59,7 @@
 
 .primary-button {
   background: color-mix(in srgb, var(--accent) 85%, #fff 15%);
-  color: #0c0d1d;
+  color: var(--text);
   border-color: color-mix(in srgb, var(--accent) 60%, transparent);
 }
 
@@ -93,7 +93,7 @@
 .panel-block {
   background: var(--spec-panel);
   border: 1px solid var(--spec-border);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 16px;
   display: grid;
   gap: 10px;
@@ -114,9 +114,9 @@
 
 .canvas-wrap {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   overflow: hidden;
-  background: #05060d;
+  background: #eef1f7;
   border: 1px solid var(--spec-border);
 }
 
@@ -149,8 +149,8 @@
 
 .readout-card {
   padding: 12px 14px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius, 6px);
+  background: #ffffff;
   border: 1px solid var(--spec-border);
 }
 

--- a/src/apps/audio-spectrum-analyser/styles.css
+++ b/src/apps/audio-spectrum-analyser/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --spec-panel: rgba(12, 14, 28, 0.55);
-  --spec-border: rgba(255, 255, 255, 0.1);
+  --spec-panel: #f6f6f9;
+  --spec-border: var(--border-soft);
   --spec-muted: rgba(247, 245, 255, 0.65);
 }
 
@@ -34,7 +34,7 @@
   font: inherit;
   font-size: 0.9rem;
   padding: 8px 12px;
-  border-radius: 12px;
+  border-radius: 0;
   border: 1px solid var(--spec-border);
   background: rgba(0, 0, 0, 0.35);
   color: var(--text);
@@ -51,7 +51,7 @@
   font-size: 0.9rem;
   font-weight: 600;
   padding: 10px 18px;
-  border-radius: 999px;
+  border-radius: 0;
   cursor: pointer;
   border: 1px solid transparent;
   transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
@@ -93,7 +93,7 @@
 .panel-block {
   background: var(--spec-panel);
   border: 1px solid var(--spec-border);
-  border-radius: 20px;
+  border-radius: 0;
   padding: 16px;
   display: grid;
   gap: 10px;
@@ -114,7 +114,7 @@
 
 .canvas-wrap {
   position: relative;
-  border-radius: 14px;
+  border-radius: 0;
   overflow: hidden;
   background: #05060d;
   border: 1px solid var(--spec-border);
@@ -149,7 +149,7 @@
 
 .readout-card {
   padding: 12px 14px;
-  border-radius: 14px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.35);
   border: 1px solid var(--spec-border);
 }

--- a/src/apps/browser-diagnostic/styles.css
+++ b/src/apps/browser-diagnostic/styles.css
@@ -7,7 +7,7 @@
 .start-button {
   justify-self: start;
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 14px 26px;
   font-weight: 700;
   font-size: 1.02rem;
@@ -60,7 +60,7 @@
   gap: 14px;
   align-items: center;
   padding: 16px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(135deg, rgba(183, 65, 14, 0.16), rgba(18, 19, 36, 0.78));
   border: 1px solid rgba(18, 18, 30, 0.06);
   position: relative;

--- a/src/apps/browser-diagnostic/styles.css
+++ b/src/apps/browser-diagnostic/styles.css
@@ -7,7 +7,7 @@
 .start-button {
   justify-self: start;
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 14px 26px;
   font-weight: 700;
   font-size: 1.02rem;
@@ -37,13 +37,13 @@
 .progress-note {
   margin: 0;
   line-height: 1.55;
-  color: rgba(255, 255, 255, 0.76);
+  color: var(--text);
   font-size: 0.98rem;
 }
 
 .progress-note {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
 }
 
 .checks-list {
@@ -60,9 +60,9 @@
   gap: 14px;
   align-items: center;
   padding: 16px 18px;
-  border-radius: 20px;
+  border-radius: 0;
   background: linear-gradient(135deg, rgba(183, 65, 14, 0.16), rgba(18, 19, 36, 0.78));
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
   position: relative;
 }
 
@@ -75,7 +75,7 @@
   font-weight: 700;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.24);
+  color: var(--text-muted);
 }
 
 .check-icon {
@@ -98,12 +98,12 @@
 
 .check-item[data-status='pending'] .check-icon::before {
   background: rgba(255, 255, 255, 0.18);
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 0 2px var(--border-soft);
 }
 
 .check-item[data-status='running'] .check-icon::before {
   border: 2px solid rgba(255, 255, 255, 0.18);
-  border-top-color: rgba(255, 255, 255, 0.78);
+  border-top-color: var(--text);
   animation: spin 900ms linear infinite;
 }
 
@@ -140,7 +140,7 @@
 .check-text {
   font-size: 0.98rem;
   line-height: 1.4;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
 }
 
 @keyframes spin {

--- a/src/apps/camera-filter-lab/styles.css
+++ b/src/apps/camera-filter-lab/styles.css
@@ -1,7 +1,7 @@
 :root {
-  --filtercam-panel-bg: rgba(6, 8, 15, 0.85);
-  --filtercam-border: rgba(18, 18, 30, 0.06);
-  --filtercam-soft-border: rgba(18, 18, 30, 0.05);
+  --filtercam-panel-bg: #ffffff;
+  --filtercam-border: rgba(18, 18, 30, 0.12);
+  --filtercam-soft-border: rgba(18, 18, 30, 0.08);
 }
 
 .filtercam {
@@ -19,9 +19,9 @@
 .filtercam-panel {
   background: var(--filtercam-panel-bg);
   border: 1px solid var(--filtercam-border);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 1.5rem;
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-deep);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -42,11 +42,11 @@
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   overflow: hidden;
   background: transparent;
   border: 1px solid rgba(18, 18, 30, 0.06);
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow-deep);
 }
 
 .filtercam-video {
@@ -169,7 +169,7 @@
 
 .filtercam-current {
   border: 1px solid var(--filtercam-soft-border);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 1.1rem;
   background: rgba(18, 18, 30, 0.03);
 }
@@ -211,7 +211,7 @@
 .filtercam-tag {
   font-size: 0.78rem;
   padding: 0.25rem 0.6rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.06);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -229,7 +229,7 @@
   gap: 0.95rem;
   width: 100%;
   padding: 0.85rem 1rem;
-  border-radius: 1rem;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--filtercam-soft-border);
   background: rgba(18, 18, 30, 0.03);
   color: inherit;
@@ -246,7 +246,9 @@
 
 .filtercam-chip.is-active {
   border-color: var(--accent, #ff5f6d);
-  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.45);
+  box-shadow:
+    var(--shadow-raised),
+    0 0 0 1px color-mix(in srgb, var(--accent, #ff5f6d) 35%, transparent);
   background: rgba(18, 18, 30, 0.05);
 }
 

--- a/src/apps/camera-filter-lab/styles.css
+++ b/src/apps/camera-filter-lab/styles.css
@@ -1,7 +1,7 @@
 :root {
   --filtercam-panel-bg: rgba(6, 8, 15, 0.85);
-  --filtercam-border: rgba(255, 255, 255, 0.08);
-  --filtercam-soft-border: rgba(255, 255, 255, 0.06);
+  --filtercam-border: rgba(18, 18, 30, 0.06);
+  --filtercam-soft-border: rgba(18, 18, 30, 0.05);
 }
 
 .filtercam {
@@ -19,7 +19,7 @@
 .filtercam-panel {
   background: var(--filtercam-panel-bg);
   border: 1px solid var(--filtercam-border);
-  border-radius: 1.5rem;
+  border-radius: 0;
   padding: 1.5rem;
   box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
   display: flex;
@@ -34,7 +34,7 @@
 
 .filtercam-panel-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   line-height: 1.4;
 }
 
@@ -42,10 +42,10 @@
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  border-radius: 1.25rem;
+  border-radius: 0;
   overflow: hidden;
-  background: radial-gradient(circle at 50% 35%, #141927, #050508 70%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: transparent;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.45);
 }
 
@@ -103,8 +103,8 @@
 .filtercam-texture--grain {
   opacity: 0.55;
   background-image:
-    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12) 0 8%, transparent 8%),
-    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.08) 0 6%, transparent 6%),
+    radial-gradient(circle at 20% 20%, var(--border-soft) 0 8%, transparent 8%),
+    radial-gradient(circle at 80% 30%, rgba(18, 18, 30, 0.06) 0 6%, transparent 6%),
     radial-gradient(circle at 40% 70%, rgba(0, 0, 0, 0.25) 0 10%, transparent 10%);
   background-size: 140px 140px, 200px 200px, 180px 180px;
   mix-blend-mode: soft-light;
@@ -131,8 +131,8 @@
 .filtercam-texture--grid {
   opacity: 0.45;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+    linear-gradient(rgba(18, 18, 30, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 18, 30, 0.06) 1px, transparent 1px);
   background-size: 40px 40px;
   mix-blend-mode: screen;
 }
@@ -169,9 +169,9 @@
 
 .filtercam-current {
   border: 1px solid var(--filtercam-soft-border);
-  border-radius: 1.1rem;
+  border-radius: 0;
   padding: 1.1rem;
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(18, 18, 30, 0.03);
 }
 
 .filtercam-current-heading {
@@ -197,7 +197,7 @@
 
 .filtercam-current-note {
   margin: 0;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   line-height: 1.4;
 }
 
@@ -211,9 +211,9 @@
 .filtercam-tag {
   font-size: 0.78rem;
   padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.06);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .filtercam-filter-grid {
@@ -231,7 +231,7 @@
   padding: 0.85rem 1rem;
   border-radius: 1rem;
   border: 1px solid var(--filtercam-soft-border);
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(18, 18, 30, 0.03);
   color: inherit;
   text-align: left;
   cursor: pointer;
@@ -239,15 +239,15 @@
 }
 
 .filtercam-chip:hover {
-  border-color: rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--text-muted);
+  background: rgba(18, 18, 30, 0.04);
   transform: translateY(-2px);
 }
 
 .filtercam-chip.is-active {
   border-color: var(--accent, #ff5f6d);
   box-shadow: 0 12px 25px rgba(0, 0, 0, 0.45);
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(18, 18, 30, 0.05);
 }
 
 .filtercam-chip-preview {
@@ -281,14 +281,14 @@
 .filtercam-chip-body em {
   font-style: normal;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text);
 }
 
 .filtercam-chip-role {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 @keyframes filtercamScan {

--- a/src/apps/clean-url-tracker-remover/styles.css
+++ b/src/apps/clean-url-tracker-remover/styles.css
@@ -8,7 +8,7 @@
   display: grid;
   gap: 18px;
   padding: clamp(22px, 3vw, 28px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -59,7 +59,7 @@
 .url-input {
   position: relative;
   z-index: 1;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: #f6f6f9;
   padding: 18px 20px;
@@ -94,7 +94,7 @@
   justify-content: center;
   gap: 8px;
   padding: 11px 20px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(18, 18, 30, 0.04);
   color: var(--text);
@@ -116,7 +116,7 @@
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.18));
   background: rgba(18, 18, 30, 0.06);
-  box-shadow: 0 16px 28px rgba(8, 14, 24, 0.4);
+  box-shadow: var(--shadow-deep);
 }
 
 .url-button.primary {
@@ -156,7 +156,7 @@
 .url-output {
   position: relative;
   z-index: 1;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: #f6f6f9;
   padding: 16px 18px;
@@ -174,7 +174,7 @@
 .status-chip {
   align-self: flex-start;
   padding: 6px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -243,7 +243,7 @@
   display: grid;
   gap: 16px;
   padding: clamp(20px, 3vw, 26px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: #ffffff;
 }
@@ -282,8 +282,8 @@
   justify-content: space-between;
   gap: 12px;
   padding: 14px 16px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.24);
+  border-radius: var(--radius, 6px);
+  background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
   font-size: 0.92rem;
 }
@@ -311,7 +311,7 @@
 .removal-value {
   justify-self: start;
   background: rgba(18, 18, 30, 0.06);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 6px 10px;
   font-size: 0.82rem;
   letter-spacing: 0.01em;
@@ -322,7 +322,7 @@
 .restore-button {
   flex-shrink: 0;
   padding: 8px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: rgba(18, 18, 30, 0.05);
   color: var(--text);

--- a/src/apps/clean-url-tracker-remover/styles.css
+++ b/src/apps/clean-url-tracker-remover/styles.css
@@ -8,11 +8,11 @@
   display: grid;
   gap: 18px;
   padding: clamp(22px, 3vw, 28px);
-  border-radius: 26px;
-  background: rgba(11, 18, 28, 0.82);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 28px 48px rgba(4, 10, 20, 0.55);
   overflow: hidden;
 }
@@ -22,7 +22,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 12% -10%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 68%);
+  background: transparent;
   opacity: 0.65;
 }
 
@@ -43,7 +43,7 @@
 
 .url-card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--text);
   font-size: 0.96rem;
   line-height: 1.6;
   max-width: 48ch;
@@ -52,31 +52,31 @@
 .url-card-footer {
   position: relative;
   z-index: 1;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
 .url-input {
   position: relative;
   z-index: 1;
-  border-radius: 20px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(4, 8, 18, 0.9);
+  background: #f6f6f9;
   padding: 18px 20px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: 1.02rem;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   line-height: 1.55;
   resize: vertical;
   min-height: clamp(160px, 24vh, 240px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.04);
 }
 
 .url-input:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.22));
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.04)),
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 45%, rgba(18, 18, 30, 0.04)),
     0 0 0 4px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
@@ -94,10 +94,10 @@
   justify-content: center;
   gap: 8px;
   padding: 11px 20px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text);
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: 0.01em;
@@ -115,7 +115,7 @@
   outline: none;
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.18));
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   box-shadow: 0 16px 28px rgba(8, 14, 24, 0.4);
 }
 
@@ -128,7 +128,7 @@
 
 .url-button.primary:hover,
 .url-button.primary:focus-visible {
-  background: color-mix(in srgb, var(--accent) 78%, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--accent) 78%, var(--border-soft));
   box-shadow:
     0 18px 32px rgba(6, 12, 20, 0.45),
     0 0 0 1px color-mix(in srgb, var(--accent) 65%, rgba(255, 255, 255, 0.15));
@@ -156,32 +156,32 @@
 .url-output {
   position: relative;
   z-index: 1;
-  border-radius: 18px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(3, 6, 14, 0.92);
+  background: #f6f6f9;
   padding: 16px 18px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: 1.08rem;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   letter-spacing: 0.01em;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.04);
 }
 
 .url-output::placeholder {
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
 }
 
 .status-chip {
   align-self: flex-start;
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: 0;
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  color: rgba(255, 255, 255, 0.78);
+  background: rgba(18, 18, 30, 0.06);
+  border: 1px solid var(--border-soft);
+  color: var(--text);
 }
 
 .status-chip[data-state='clean'] {
@@ -203,9 +203,9 @@
 }
 
 .status-chip[data-state='idle'] {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.16);
-  color: rgba(255, 255, 255, 0.7);
+  background: rgba(18, 18, 30, 0.06);
+  border-color: var(--border-soft);
+  color: var(--text-muted);
 }
 
 .url-card[data-state='error'] {
@@ -222,7 +222,7 @@
   display: grid;
   gap: 8px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
 }
 
 .meta-row {
@@ -236,16 +236,16 @@
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .removal-summary {
   display: grid;
   gap: 16px;
   padding: clamp(20px, 3vw, 26px);
-  border-radius: 24px;
+  border-radius: 0;
   border: 1px dashed rgba(255, 255, 255, 0.18);
-  background: rgba(8, 12, 22, 0.72);
+  background: #ffffff;
 }
 
 .removal-summary h3 {
@@ -256,7 +256,7 @@
 
 .removal-summary .empty-hint {
   margin: 0;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
@@ -282,9 +282,9 @@
   justify-content: space-between;
   gap: 12px;
   padding: 14px 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.24);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
   font-size: 0.92rem;
 }
 
@@ -305,27 +305,27 @@
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .removal-value {
   justify-self: start;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
+  background: rgba(18, 18, 30, 0.06);
+  border-radius: 0;
   padding: 6px 10px;
   font-size: 0.82rem;
   letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
   word-break: break-all;
 }
 
 .restore-button {
   flex-shrink: 0;
   padding: 8px 16px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(255, 255, 255, 0.9);
+  background: rgba(18, 18, 30, 0.05);
+  color: var(--text);
   font-weight: 600;
   font-size: 0.85rem;
   cursor: pointer;
@@ -340,7 +340,7 @@
   outline: none;
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.18));
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-soft);
 }
 
 @media (max-width: 640px) {

--- a/src/apps/clipboard-alchemist/styles.css
+++ b/src/apps/clipboard-alchemist/styles.css
@@ -1,6 +1,6 @@
 .warning-banner {
   padding: 18px 22px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(255, 107, 129, 0.18);
   border: 1px solid rgba(255, 107, 129, 0.4);
   font-weight: 600;
@@ -21,9 +21,9 @@
 
 .actions-panel,
 .preview-panel {
-  background: rgba(18, 19, 36, 0.82);
-  border-radius: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #ffffff;
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   padding: clamp(20px, 3vw, 32px);
   display: grid;
   gap: 20px;
@@ -37,9 +37,9 @@
 
 .action-card {
   padding: 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 14, 26, 0.82);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  background: #f6f6f9;
   display: grid;
   gap: 12px;
 }
@@ -52,14 +52,14 @@
 
 .action-card header p {
   margin: 6px 0 0 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
   font-size: 0.92rem;
   line-height: 1.4;
 }
 
 .action-btn {
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 11px 18px;
   font-weight: 600;
   background: rgba(90, 228, 167, 0.16);
@@ -93,12 +93,12 @@
   display: grid;
   gap: 6px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .find-replace-inputs input {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.24);
   padding: 10px 12px;
   color: inherit;
@@ -113,11 +113,11 @@
 .status-toast {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   opacity: 0;
   transform: translateY(8px);
   transition: opacity 200ms ease, transform 200ms ease;
@@ -134,9 +134,9 @@
 }
 
 .refresh-btn {
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   color: inherit;
   padding: 10px 18px;
   font-weight: 600;
@@ -166,7 +166,7 @@
 .preview-header p {
   margin: 6px 0 0 0;
   font-size: 0.88rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .preview-field {
@@ -179,18 +179,18 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.52);
+  color: var(--text-muted);
 }
 
 .preview-field textarea {
   min-height: 140px;
   padding: 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
   resize: vertical;
 }
 

--- a/src/apps/clipboard-alchemist/styles.css
+++ b/src/apps/clipboard-alchemist/styles.css
@@ -1,6 +1,6 @@
 .warning-banner {
   padding: 18px 22px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(255, 107, 129, 0.18);
   border: 1px solid rgba(255, 107, 129, 0.4);
   font-weight: 600;
@@ -22,7 +22,7 @@
 .actions-panel,
 .preview-panel {
   background: #ffffff;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   padding: clamp(20px, 3vw, 32px);
   display: grid;
@@ -37,7 +37,7 @@
 
 .action-card {
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: #f6f6f9;
   display: grid;
@@ -59,7 +59,7 @@
 
 .action-btn {
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 11px 18px;
   font-weight: 600;
   background: rgba(90, 228, 167, 0.16);
@@ -97,9 +97,9 @@
 }
 
 .find-replace-inputs input {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.24);
+  background: rgba(18, 18, 30, 0.05);
   padding: 10px 12px;
   color: inherit;
   font-size: 0.95rem;
@@ -113,8 +113,8 @@
 .status-toast {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius, 6px);
+  background: rgba(18, 18, 30, 0.06);
   border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
   color: var(--text);
@@ -134,7 +134,7 @@
 }
 
 .refresh-btn {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(18, 18, 30, 0.06);
   color: inherit;
@@ -185,7 +185,7 @@
 .preview-field textarea {
   min-height: 140px;
   padding: 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;

--- a/src/apps/create-dot-to-dot-designer/styles.css
+++ b/src/apps/create-dot-to-dot-designer/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --dot-bg: rgba(9, 14, 28, 0.8);
-  --dot-border: rgba(255, 255, 255, 0.12);
+  --dot-bg: #ffffff;
+  --dot-border: var(--border-soft);
 }
 
 .dot-app {
@@ -21,7 +21,7 @@
   margin: 0;
   font-size: 0.98rem;
   line-height: 1.5;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
 }
 
 .dot-button-group {
@@ -31,10 +31,10 @@
 }
 
 .dot-button {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 999px;
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.06);
+  border: 1px solid var(--border-soft);
+  border-radius: 0;
+  color: var(--text);
   padding: 10px 20px;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -46,7 +46,7 @@
 .dot-button:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.3));
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--border-soft);
   box-shadow: 0 12px 24px rgba(6, 9, 18, 0.35);
   transform: translateY(-1px);
 }
@@ -66,9 +66,9 @@
 
 .dot-stat-card {
   padding: 18px 20px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px solid var(--border-soft);
   display: grid;
   gap: 6px;
   min-height: 110px;
@@ -77,24 +77,24 @@
 .dot-stat-card strong {
   font-size: clamp(1.8rem, 3vw, 2.1rem);
   letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.95);
+  color: var(--text);
 }
 
 .dot-stat-card span {
   font-size: 0.9rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .dot-stage {
   position: relative;
-  border-radius: 32px;
+  border-radius: 0;
   border: 1px solid var(--dot-border);
-  background: radial-gradient(circle at 10% 10%, color-mix(in srgb, var(--accent) 30%, transparent) 0%, transparent 55%), var(--dot-bg);
+  background: transparent;
   padding: clamp(12px, 2vw, 18px);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 rgba(18, 18, 30, 0.04),
     0 35px 45px rgba(4, 6, 12, 0.55);
 }
 
@@ -102,17 +102,17 @@
   content: '';
   position: absolute;
   inset: 10px;
-  border-radius: 26px;
+  border-radius: 0;
   pointer-events: none;
-  border: 1px dashed rgba(255, 255, 255, 0.06);
+  border: 1px dashed rgba(18, 18, 30, 0.05);
 }
 
 .dot-stage-message {
   position: absolute;
   inset: clamp(12px, 2vw, 20px);
-  border-radius: 26px;
-  background: rgba(4, 7, 14, 0.85);
-  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 0;
+  background: #f6f6f9;
+  border: 1px dashed var(--border-soft);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -120,7 +120,7 @@
   gap: 6px;
   text-align: center;
   font-size: 1rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
   transition: opacity 200ms ease;
   pointer-events: none;
   z-index: 2;
@@ -130,7 +130,7 @@
   font-size: 1.1rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
 }
 
 .dot-stage[data-has-points='true'] .dot-stage-message {
@@ -141,11 +141,11 @@
   width: 100%;
   height: clamp(360px, 58vh, 620px);
   display: block;
-  border-radius: 24px;
+  border-radius: 0;
   overflow: hidden;
   background-image:
-    linear-gradient(transparent 95%, rgba(255, 255, 255, 0.04) 95%),
-    linear-gradient(90deg, transparent 95%, rgba(255, 255, 255, 0.04) 95%);
+    linear-gradient(transparent 95%, rgba(18, 18, 30, 0.04) 95%),
+    linear-gradient(90deg, transparent 95%, rgba(18, 18, 30, 0.04) 95%);
   background-size: 40px 40px;
   touch-action: none;
   cursor: crosshair;
@@ -168,23 +168,23 @@
 
 .dot-node-halo {
   fill: rgba(8, 12, 22, 0.95);
-  stroke: rgba(255, 255, 255, 0.12);
+  stroke: var(--border-soft);
   stroke-width: 1;
 }
 
 .dot-node-point {
-  fill: rgba(255, 255, 255, 0.95);
-  stroke: rgba(10, 14, 26, 0.8);
+  fill: var(--accent);
+  stroke: rgba(255, 255, 255, 0.95);
   stroke-width: 2;
 }
 
 .dot-node-label {
-  fill: rgba(255, 255, 255, 0.98);
+  fill: #14141a;
   font-size: 0.85rem;
   font-weight: 600;
   text-anchor: middle;
   paint-order: stroke fill;
-  stroke: rgba(5, 8, 15, 0.9);
+  stroke: rgba(255, 255, 255, 0.92);
   stroke-width: 4px;
   letter-spacing: 0.1em;
 }
@@ -217,12 +217,12 @@
 }
 
 .dot-preview-label {
-  fill: rgba(255, 255, 255, 0.95);
+  fill: #14141a;
   font-size: 0.85rem;
   font-weight: 600;
   text-anchor: middle;
   paint-order: stroke fill;
-  stroke: rgba(8, 10, 20, 0.9);
+  stroke: rgba(255, 255, 255, 0.92);
   stroke-width: 4px;
 }
 

--- a/src/apps/create-dot-to-dot-designer/styles.css
+++ b/src/apps/create-dot-to-dot-designer/styles.css
@@ -33,7 +33,7 @@
 .dot-button {
   background: rgba(18, 18, 30, 0.06);
   border: 1px solid var(--border-soft);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   color: var(--text);
   padding: 10px 20px;
   font-weight: 600;
@@ -47,7 +47,7 @@
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.3));
   background: var(--border-soft);
-  box-shadow: 0 12px 24px rgba(6, 9, 18, 0.35);
+  box-shadow: var(--shadow-deep);
   transform: translateY(-1px);
 }
 
@@ -66,7 +66,7 @@
 
 .dot-stat-card {
   padding: 18px 20px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
   display: grid;
@@ -89,7 +89,7 @@
 
 .dot-stage {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--dot-border);
   background: transparent;
   padding: clamp(12px, 2vw, 18px);
@@ -102,7 +102,7 @@
   content: '';
   position: absolute;
   inset: 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   pointer-events: none;
   border: 1px dashed rgba(18, 18, 30, 0.05);
 }
@@ -110,7 +110,7 @@
 .dot-stage-message {
   position: absolute;
   inset: clamp(12px, 2vw, 20px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #f6f6f9;
   border: 1px dashed var(--border-soft);
   display: flex;
@@ -141,7 +141,7 @@
   width: 100%;
   height: clamp(360px, 58vh, 620px);
   display: block;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   overflow: hidden;
   background-image:
     linear-gradient(transparent 95%, rgba(18, 18, 30, 0.04) 95%),

--- a/src/apps/markdown-repair/styles.css
+++ b/src/apps/markdown-repair/styles.css
@@ -8,11 +8,11 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 28px);
-  border-radius: 26px;
-  background: rgba(11, 14, 27, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 25px 45px rgba(6, 7, 13, 0.55);
   overflow: hidden;
 }
@@ -22,7 +22,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 10% -15%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 60%);
+  background: transparent;
   opacity: 0.55;
 }
 
@@ -41,7 +41,7 @@
 
 .mdr-card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -58,10 +58,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.05);
+  color: var(--text);
   padding: 10px 16px;
   font-weight: 600;
   font-size: 0.92rem;
@@ -71,7 +71,7 @@
 }
 
 .mdr-btn.primary {
-  background: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.06));
+  background: color-mix(in srgb, var(--accent) 40%, rgba(18, 18, 30, 0.05));
   border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.22));
 }
 
@@ -79,7 +79,7 @@
 .mdr-btn:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22));
-  background: color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--accent) 22%, rgba(18, 18, 30, 0.06));
   transform: translateY(-1px);
   box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
 }
@@ -92,18 +92,18 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .mdr-textarea {
   position: relative;
   z-index: 1;
   min-height: clamp(280px, 35vh, 420px);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(3, 5, 15, 0.84);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px 18px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: clamp(0.9rem, 1.6vw, 1rem);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   line-height: 1.55;
@@ -123,12 +123,12 @@
   flex-wrap: wrap;
   gap: 14px;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .mdr-stat strong {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .mdr-options-grid {
@@ -144,7 +144,7 @@
   align-items: center;
   gap: 10px;
   font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
   cursor: pointer;
 }
 
@@ -156,11 +156,11 @@
 .mdr-status {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   opacity: 0;
   transform: translateY(8px);
   transition: opacity 200ms ease, transform 200ms ease;

--- a/src/apps/markdown-repair/styles.css
+++ b/src/apps/markdown-repair/styles.css
@@ -8,7 +8,7 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 28px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -58,7 +58,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(18, 18, 30, 0.05);
   color: var(--text);
@@ -81,7 +81,7 @@
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22));
   background: color-mix(in srgb, var(--accent) 22%, rgba(18, 18, 30, 0.06));
   transform: translateY(-1px);
-  box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
+  box-shadow: var(--shadow-deep);
 }
 
 .mdr-field-label {
@@ -99,7 +99,7 @@
   position: relative;
   z-index: 1;
   min-height: clamp(280px, 35vh, 420px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px 18px;
@@ -156,8 +156,8 @@
 .mdr-status {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius, 6px);
+  background: rgba(18, 18, 30, 0.06);
   border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
   color: var(--text);

--- a/src/apps/morse-code-studio/styles.css
+++ b/src/apps/morse-code-studio/styles.css
@@ -19,11 +19,11 @@
   display: grid;
   gap: 16px;
   padding: clamp(22px, 3vw, 32px);
-  border-radius: 26px;
+  border-radius: 0;
   background: rgba(8, 11, 24, 0.88);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 rgba(18, 18, 30, 0.04),
     0 20px 50px rgba(5, 6, 12, 0.6);
 }
 
@@ -31,7 +31,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 10% -20%, color-mix(in srgb, var(--accent) 45%, transparent) 0%, transparent 65%);
+  background: transparent;
   opacity: 0.55;
   pointer-events: none;
 }
@@ -54,7 +54,7 @@
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.24em;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
 }
 
 .card-header h2 {
@@ -66,7 +66,7 @@
 .card-description {
   position: relative;
   margin: 0;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   line-height: 1.6;
   z-index: 1;
 }
@@ -86,8 +86,8 @@
 
 .telemetry-grid article {
   padding: 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(3, 5, 14, 0.85);
   display: grid;
   gap: 8px;
@@ -98,7 +98,7 @@
   font-size: 0.8rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .status-value {
@@ -122,8 +122,8 @@
   position: relative;
   z-index: 1;
   padding: 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(3, 5, 14, 0.9);
   display: grid;
   gap: 10px;
@@ -162,8 +162,8 @@
   width: 100%;
   border: none;
   padding: clamp(18px, 3vw, 28px);
-  border-radius: 999px;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 85%, #111) 0%, rgba(255, 255, 255, 0.05) 100%);
+  border-radius: 0;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 85%, #111) 0%, rgba(18, 18, 30, 0.05) 100%);
   color: #05060d;
   font-size: clamp(1.05rem, 2.4vw, 1.2rem);
   font-weight: 700;
@@ -183,7 +183,7 @@
 .micro-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .mic-card::before {
@@ -203,13 +203,13 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.24);
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(18, 18, 30, 0.04);
   padding: 10px 18px;
   font-size: 0.95rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   cursor: pointer;
   transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
@@ -217,7 +217,7 @@
 .ghost-button:hover:not(:disabled),
 .ghost-button:focus-visible:not(:disabled) {
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.25));
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   transform: translateY(-1px);
 }
 
@@ -236,8 +236,8 @@
 .level-bar {
   position: relative;
   height: 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.06);
   overflow: hidden;
 }
 
@@ -252,7 +252,7 @@
 
 .level-value {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
 }
 
 .threshold-field {
@@ -274,11 +274,11 @@
 .encoder-card textarea {
   position: relative;
   z-index: 1;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(6, 8, 18, 0.92);
   padding: 14px 16px;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
   font-size: 1rem;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   line-height: 1.5;
@@ -291,9 +291,9 @@
   z-index: 1;
   margin: 0;
   padding: 14px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   border: 1px dashed rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(18, 18, 30, 0.04);
   font-size: 1rem;
   min-height: 1.5em;
 }
@@ -306,7 +306,7 @@
   justify-content: space-between;
   gap: 12px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .encoder-stats label {
@@ -324,8 +324,8 @@
   z-index: 1;
   margin: 0;
   padding: 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(6, 8, 18, 0.92);
   min-height: 120px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;

--- a/src/apps/morse-code-studio/styles.css
+++ b/src/apps/morse-code-studio/styles.css
@@ -19,7 +19,7 @@
   display: grid;
   gap: 16px;
   padding: clamp(22px, 3vw, 32px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(8, 11, 24, 0.88);
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -86,7 +86,7 @@
 
 .telemetry-grid article {
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(3, 5, 14, 0.85);
   display: grid;
@@ -122,7 +122,7 @@
   position: relative;
   z-index: 1;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(3, 5, 14, 0.9);
   display: grid;
@@ -162,22 +162,22 @@
   width: 100%;
   border: none;
   padding: clamp(18px, 3vw, 28px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 85%, #111) 0%, rgba(18, 18, 30, 0.05) 100%);
-  color: #05060d;
+  color: var(--text);
   font-size: clamp(1.05rem, 2.4vw, 1.2rem);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   cursor: pointer;
-  box-shadow: 0 25px 45px rgba(5, 7, 17, 0.55);
+  box-shadow: var(--shadow-deep);
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
 .transmit-button:active,
 .morse-card[data-active='true'] .transmit-button {
   transform: translateY(2px);
-  box-shadow: 0 15px 26px rgba(5, 7, 17, 0.4);
+  box-shadow: var(--shadow-raised);
 }
 
 .micro-hint {
@@ -203,7 +203,7 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.24);
   background: rgba(18, 18, 30, 0.04);
   padding: 10px 18px;
@@ -236,7 +236,7 @@
 .level-bar {
   position: relative;
   height: 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.06);
   overflow: hidden;
 }
@@ -274,7 +274,7 @@
 .encoder-card textarea {
   position: relative;
   z-index: 1;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(6, 8, 18, 0.92);
   padding: 14px 16px;
@@ -291,7 +291,7 @@
   z-index: 1;
   margin: 0;
   padding: 14px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(18, 18, 30, 0.04);
   font-size: 1rem;
@@ -324,7 +324,7 @@
   z-index: 1;
   margin: 0;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(6, 8, 18, 0.92);
   min-height: 120px;

--- a/src/apps/nesting-algorithm-visualizer/styles.css
+++ b/src/apps/nesting-algorithm-visualizer/styles.css
@@ -16,11 +16,11 @@
   display: grid;
   gap: clamp(18px, 3vw, 26px);
   padding: clamp(22px, 3vw, 30px);
-  border-radius: 28px;
+  border-radius: 0;
   background: rgba(8, 10, 20, 0.82);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 32px 50px rgba(5, 8, 15, 0.55);
   overflow: hidden;
 }
@@ -31,12 +31,12 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 10% -15%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 58%);
+  background: transparent;
   opacity: 0.6;
 }
 
 .canvas-panel::before {
-  background: radial-gradient(circle at 85% 0%, color-mix(in srgb, var(--accent) 45%, transparent) 0%, transparent 60%);
+  background: transparent;
   opacity: 0.65;
 }
 
@@ -55,7 +55,7 @@
 .controls-header p,
 .canvas-header p {
   margin: 6px 0 0;
-  color: rgba(255, 255, 255, 0.66);
+  color: var(--text);
   font-size: 0.95rem;
   line-height: 1.5;
 }
@@ -79,18 +79,18 @@
   display: grid;
   gap: 12px;
   padding: 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(15, 19, 35, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .control-group {
   display: grid;
   gap: 10px;
   padding: 14px 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(15, 19, 35, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .control-group > div {
@@ -119,7 +119,7 @@
 .control-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .toggle-list {
@@ -133,7 +133,7 @@
   align-items: center;
   gap: 12px;
   padding: 12px 14px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(15, 19, 35, 0.74);
   border: 1px solid rgba(255, 255, 255, 0.07);
   cursor: pointer;
@@ -149,16 +149,16 @@
   display: grid;
   gap: 8px;
   padding: 14px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(15, 19, 35, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .select-control select,
 .number-control input {
   padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 6, 23, 0.6);
   color: #fff;
   font-size: 1rem;
@@ -178,7 +178,7 @@
   flex: 1 1 auto;
   min-width: 150px;
   padding: 11px 18px;
-  border-radius: 14px;
+  border-radius: 0;
   border: none;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -221,7 +221,7 @@
 }
 
 .solve-summary dt {
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .solve-summary dd {
@@ -240,9 +240,9 @@
 }
 
 .canvas-viewport {
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: #0f172a;
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  background: #f6f6f9;
   overflow: auto;
   max-height: min(70vh, 720px);
 }
@@ -256,9 +256,9 @@
   list-style: none;
   margin: 0;
   padding: 14px 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(14, 18, 32, 0.75);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(18, 18, 30, 0.05);
   display: grid;
   gap: 8px;
   font-size: 0.92rem;
@@ -267,11 +267,11 @@
 .fail-headline {
   margin: 0;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .failure-list li {
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
 }
 
 .all-fit {
@@ -290,9 +290,9 @@
   display: grid;
   gap: 12px;
   padding: 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(14, 18, 32, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .add-rect-panel .add-rect-grid {
@@ -309,8 +309,8 @@
 
 .add-rect-panel input {
   padding: 8px 10px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 6, 23, 0.6);
   color: #fff;
 }
@@ -320,9 +320,9 @@
   display: grid;
   gap: 12px;
   padding: 18px;
-  border-radius: 22px;
+  border-radius: 0;
   background: rgba(8, 11, 22, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .inventory-panel header h3 {
@@ -331,7 +331,7 @@
 
 .inventory-panel header p {
   margin: 4px 0 0;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
@@ -349,9 +349,9 @@
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
-  border-radius: 14px;
+  border-radius: 0;
   background: rgba(2, 6, 23, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(18, 18, 30, 0.05);
 }
 
 .inventory-list li::before {

--- a/src/apps/nesting-algorithm-visualizer/styles.css
+++ b/src/apps/nesting-algorithm-visualizer/styles.css
@@ -16,7 +16,7 @@
   display: grid;
   gap: clamp(18px, 3vw, 26px);
   padding: clamp(22px, 3vw, 30px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(8, 10, 20, 0.82);
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -79,7 +79,7 @@
   display: grid;
   gap: 12px;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(15, 19, 35, 0.78);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -88,7 +88,7 @@
   display: grid;
   gap: 10px;
   padding: 14px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(15, 19, 35, 0.78);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -133,7 +133,7 @@
   align-items: center;
   gap: 12px;
   padding: 12px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(15, 19, 35, 0.74);
   border: 1px solid rgba(255, 255, 255, 0.07);
   cursor: pointer;
@@ -149,7 +149,7 @@
   display: grid;
   gap: 8px;
   padding: 14px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(15, 19, 35, 0.78);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -157,7 +157,7 @@
 .select-control select,
 .number-control input {
   padding: 10px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 6, 23, 0.6);
   color: #fff;
@@ -178,20 +178,20 @@
   flex: 1 1 auto;
   min-width: 150px;
   padding: 11px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: none;
   font-weight: 600;
   letter-spacing: 0.01em;
   color: #0b101e;
   background: var(--btn-color, var(--accent));
-  box-shadow: 0 14px 30px rgba(11, 16, 30, 0.42);
+  box-shadow: var(--shadow-deep);
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .lab-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(11, 16, 30, 0.48);
+  box-shadow: var(--shadow-deep);
 }
 
 .solve-summary {
@@ -240,7 +240,7 @@
 }
 
 .canvas-viewport {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: #f6f6f9;
   overflow: auto;
@@ -256,7 +256,7 @@
   list-style: none;
   margin: 0;
   padding: 14px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(14, 18, 32, 0.75);
   border: 1px solid rgba(18, 18, 30, 0.05);
   display: grid;
@@ -290,7 +290,7 @@
   display: grid;
   gap: 12px;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(14, 18, 32, 0.78);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -309,7 +309,7 @@
 
 .add-rect-panel input {
   padding: 8px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 6, 23, 0.6);
   color: #fff;
@@ -320,7 +320,7 @@
   display: grid;
   gap: 12px;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(8, 11, 22, 0.78);
   border: 1px solid rgba(18, 18, 30, 0.06);
 }
@@ -349,7 +349,7 @@
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(2, 6, 23, 0.6);
   border: 1px solid rgba(18, 18, 30, 0.05);
 }

--- a/src/apps/palette-maker/styles.css
+++ b/src/apps/palette-maker/styles.css
@@ -6,12 +6,12 @@
 
 .panel {
   background: #ffffff;
-  border-radius: 0;
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius, 6px);
+  border: 1px solid var(--border-soft);
   padding: clamp(20px, 3vw, 30px);
   display: grid;
   gap: clamp(14px, 2vw, 22px);
-  box-shadow: 0 25px 65px -65px rgba(0, 0, 0, 0.8), inset 0 0 0 1px rgba(18, 18, 30, 0.04);
+  box-shadow: var(--shadow-deep), inset 0 0 0 1px rgba(18, 18, 30, 0.06);
 }
 
 .panel-header h2 {
@@ -21,7 +21,7 @@
 
 .panel-header p {
   margin: 6px 0 0;
-  color: var(--text);
+  color: var(--text-muted);
   font-size: 0.9rem;
   line-height: 1.4;
 }
@@ -36,7 +36,7 @@
   border-radius: 100%;
   cursor: crosshair;
   box-shadow:
-    0 12px 28px rgba(16, 16, 28, 0.08),
+    0 2px 6px rgba(16, 16, 28, 0.06),
     inset 0 0 0 1px rgba(18, 18, 30, 0.08);
   background: radial-gradient(circle at center, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
   transition: transform 180ms ease;
@@ -56,7 +56,7 @@
 
 .chip-btn {
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 18px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -68,7 +68,7 @@
 
 .chip-btn.primary {
   background: color-mix(in srgb, var(--accent, #f6b44e) 55%, var(--border-soft));
-  box-shadow: 0 14px 32px -26px var(--accent, #f6b44e);
+  box-shadow: 0 2px 5px color-mix(in srgb, var(--accent, #f6b44e) 25%, transparent);
 }
 
 .chip-btn:hover,
@@ -96,7 +96,7 @@
   align-items: center;
   gap: 8px;
   background: rgba(18, 18, 30, 0.05);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 8px 14px;
   font-size: 0.85rem;
   color: var(--text);
@@ -109,7 +109,7 @@
   height: 12px;
   border-radius: 50%;
   background: var(--badge-color, #f6b44e);
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 0 2px rgba(18, 18, 30, 0.1);
 }
 
 .color-list {
@@ -127,9 +127,9 @@
 .color-swatch {
   width: 64px;
   height: 64px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: var(--swatch-color, #333);
-  box-shadow: inset 0 0 0 1px var(--border-soft), 0 18px 35px -28px rgba(0, 0, 0, 0.7);
+  box-shadow: inset 0 0 0 1px var(--border-soft), var(--shadow-raised);
 }
 
 .color-meta {
@@ -152,7 +152,7 @@
 .icon-btn {
   border: none;
   background: rgba(18, 18, 30, 0.06);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 6px 10px;
   cursor: pointer;
   font-size: 0.85rem;
@@ -175,16 +175,16 @@
   width: 100%;
   height: 42px;
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: transparent;
   padding: 0;
   cursor: pointer;
 }
 
 .color-meta__controls input[type='text'] {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(18, 18, 30, 0.05);
   padding: 10px 12px;
   color: inherit;
   font-size: 0.95rem;
@@ -206,7 +206,7 @@
 
 .color-metrics div {
   background: rgba(18, 18, 30, 0.04);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px;
   text-align: center;
 }
@@ -242,7 +242,7 @@
   grid-template-columns: 56px 1fr;
   gap: 16px;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(12, 14, 28, 0.65);
   border: 1px solid rgba(18, 18, 30, 0.05);
   box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
@@ -301,7 +301,7 @@
 }
 
 .contrast-sample {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 18px;
   display: grid;
   gap: 10px;
@@ -338,7 +338,7 @@
   align-items: center;
   gap: 18px;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(9, 10, 20, 0.65);
   border: 1px solid rgba(18, 18, 30, 0.05);
 }
@@ -352,7 +352,7 @@
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18), 0 14px 28px -20px rgba(0, 0, 0, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18), var(--shadow-deep);
   transform: translateX(calc(var(--offset, 0) * 2px));
 }
 
@@ -389,7 +389,7 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(12, 14, 28, 0.6);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   color: var(--text-muted);

--- a/src/apps/palette-maker/styles.css
+++ b/src/apps/palette-maker/styles.css
@@ -5,13 +5,13 @@
 }
 
 .panel {
-  background: rgba(18, 19, 36, 0.82);
-  border-radius: 26px;
+  background: #ffffff;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.07);
   padding: clamp(20px, 3vw, 30px);
   display: grid;
   gap: clamp(14px, 2vw, 22px);
-  box-shadow: 0 25px 65px -65px rgba(0, 0, 0, 0.8), inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  box-shadow: 0 25px 65px -65px rgba(0, 0, 0, 0.8), inset 0 0 0 1px rgba(18, 18, 30, 0.04);
 }
 
 .panel-header h2 {
@@ -21,7 +21,7 @@
 
 .panel-header p {
   margin: 6px 0 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
   font-size: 0.9rem;
   line-height: 1.4;
 }
@@ -35,8 +35,10 @@
   aspect-ratio: 1;
   border-radius: 100%;
   cursor: crosshair;
-  box-shadow: 0 28px 60px -40px rgba(0, 0, 0, 0.9), inset 0 0 0 1px rgba(255, 255, 255, 0.06);
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0));
+  box-shadow:
+    0 12px 28px rgba(16, 16, 28, 0.08),
+    inset 0 0 0 1px rgba(18, 18, 30, 0.08);
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
   transition: transform 180ms ease;
 }
 
@@ -54,24 +56,24 @@
 
 .chip-btn {
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 10px 18px;
   font-weight: 600;
   font-size: 0.9rem;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   color: inherit;
   cursor: pointer;
   transition: background 180ms ease, transform 180ms ease;
 }
 
 .chip-btn.primary {
-  background: color-mix(in srgb, var(--accent, #f6b44e) 55%, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--accent, #f6b44e) 55%, var(--border-soft));
   box-shadow: 0 14px 32px -26px var(--accent, #f6b44e);
 }
 
 .chip-btn:hover,
 .chip-btn:focus-visible {
-  background: color-mix(in srgb, var(--accent, #f6b44e) 35%, rgba(255, 255, 255, 0.16));
+  background: color-mix(in srgb, var(--accent, #f6b44e) 35%, var(--border-soft));
   transform: translateY(-1px);
   outline: none;
 }
@@ -79,25 +81,25 @@
 .chip-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(18, 18, 30, 0.05);
   transform: none;
 }
 
 .chip-btn:disabled:hover,
 .chip-btn:disabled:focus-visible {
   transform: none;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(18, 18, 30, 0.05);
 }
 
 .last-picked {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 999px;
+  background: rgba(18, 18, 30, 0.05);
+  border-radius: 0;
   padding: 8px 14px;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text);
   position: relative;
 }
 
@@ -125,9 +127,9 @@
 .color-swatch {
   width: 64px;
   height: 64px;
-  border-radius: 18px;
+  border-radius: 0;
   background: var(--swatch-color, #333);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 18px 35px -28px rgba(0, 0, 0, 0.7);
+  box-shadow: inset 0 0 0 1px var(--border-soft), 0 18px 35px -28px rgba(0, 0, 0, 0.7);
 }
 
 .color-meta {
@@ -149,17 +151,17 @@
 
 .icon-btn {
   border: none;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
+  background: rgba(18, 18, 30, 0.06);
+  border-radius: 0;
   padding: 6px 10px;
   cursor: pointer;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
 }
 
 .icon-btn:hover,
 .icon-btn:focus-visible {
-  background: rgba(255, 255, 255, 0.14);
+  background: var(--border-soft);
   outline: none;
 }
 
@@ -173,15 +175,15 @@
   width: 100%;
   height: 42px;
   border: none;
-  border-radius: 14px;
+  border-radius: 0;
   background: transparent;
   padding: 0;
   cursor: pointer;
 }
 
 .color-meta__controls input[type='text'] {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.25);
   padding: 10px 12px;
   color: inherit;
@@ -203,8 +205,8 @@
 }
 
 .color-metrics div {
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 12px;
+  background: rgba(18, 18, 30, 0.04);
+  border-radius: 0;
   padding: 10px;
   text-align: center;
 }
@@ -214,20 +216,20 @@
   font-size: 0.7rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .color-metrics dd {
   margin: 6px 0 0;
   font-family: 'Fira Code', 'Space Mono', monospace;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
 }
 
 .contrast-summary {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .suggestion-list {
@@ -240,10 +242,10 @@
   grid-template-columns: 56px 1fr;
   gap: 16px;
   padding: 16px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(12, 14, 28, 0.65);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(18, 18, 30, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
 }
 
 .suggestion-info {
@@ -259,14 +261,14 @@
 .suggestion-info p {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .suggestion-meta {
   font-size: 0.8rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .rating-wrap {
@@ -284,13 +286,13 @@
   content: attr(data-value) ' / 5';
   margin-left: 8px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .rating-reason {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .contrast-wrap {
@@ -299,7 +301,7 @@
 }
 
 .contrast-sample {
-  border-radius: 20px;
+  border-radius: 0;
   padding: 18px;
   display: grid;
   gap: 10px;
@@ -315,7 +317,7 @@
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .contrast-sample .sample-text {
@@ -327,7 +329,7 @@
 
 .contrast-note {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .logo-preview {
@@ -336,9 +338,9 @@
   align-items: center;
   gap: 18px;
   padding: 16px;
-  border-radius: 20px;
+  border-radius: 0;
   background: rgba(9, 10, 20, 0.65);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(18, 18, 30, 0.05);
 }
 
 .logo-mark {
@@ -357,7 +359,7 @@
 .logo-title {
   font-size: 1rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--text);
 }
 
 .resource-links {
@@ -387,10 +389,10 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(12, 14, 28, 0.6);
   border: 1px dashed rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
   text-align: center;
   font-size: 0.9rem;
 }

--- a/src/apps/pdf-forensic-analysis/styles.css
+++ b/src/apps/pdf-forensic-analysis/styles.css
@@ -11,7 +11,7 @@
 }
 
 .panel {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #ffffff;
   box-shadow:
@@ -44,7 +44,7 @@
 
 .drop-zone {
   border: 2px dashed rgba(255, 255, 255, 0.25);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 48px 28px;
   text-align: center;
   cursor: pointer;
@@ -83,7 +83,7 @@
 
 .status-line {
   padding: 12px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(9, 11, 24, 0.65);
   font-size: 0.9rem;
@@ -105,7 +105,7 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(8, 9, 20, 0.72);
   font-size: 0.95rem;
@@ -116,7 +116,7 @@
   display: grid;
   gap: 14px;
   padding: clamp(16px, 2.5vw, 26px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(10, 12, 28, 0.8);
   box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
@@ -212,9 +212,9 @@
 
 .preview pre,
 .preview textarea {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
-  background: rgba(0, 0, 0, 0.32);
+  background: rgba(18, 18, 30, 0.06);
   padding: 14px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.9rem;
@@ -236,9 +236,9 @@
 
 .image-card {
   padding: 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(18, 18, 30, 0.05);
   font-size: 0.85rem;
 }
 
@@ -262,7 +262,7 @@
 
 .font-chip {
   padding: 6px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: var(--border-soft);
   border: 1px solid rgba(255, 255, 255, 0.15);
   font-size: 0.88rem;

--- a/src/apps/pdf-forensic-analysis/styles.css
+++ b/src/apps/pdf-forensic-analysis/styles.css
@@ -11,9 +11,13 @@
 }
 
 .panel {
-  border-radius: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(150deg, rgba(25, 21, 46, 0.92), rgba(15, 12, 30, 0.86));
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #ffffff;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 12px 28px rgba(16, 16, 28, 0.07);
   padding: clamp(22px, 3.5vw, 36px);
   display: grid;
   gap: clamp(18px, 2.5vw, 28px);
@@ -33,14 +37,14 @@
 
 .panel-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.5;
 }
 
 .drop-zone {
   border: 2px dashed rgba(255, 255, 255, 0.25);
-  border-radius: 22px;
+  border-radius: 0;
   padding: 48px 28px;
   text-align: center;
   cursor: pointer;
@@ -68,29 +72,29 @@
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0 6px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .drop-zone .hint {
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
   margin: 0;
 }
 
 .status-line {
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(9, 11, 24, 0.65);
   font-size: 0.9rem;
   letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .results-meta {
   margin: 0;
   font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .results-list {
@@ -101,21 +105,21 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(8, 9, 20, 0.72);
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text);
 }
 
 .result-card {
   display: grid;
   gap: 14px;
   padding: clamp(16px, 2.5vw, 26px);
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(10, 12, 28, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
   position: relative;
   overflow: hidden;
 }
@@ -135,7 +139,7 @@
 }
 
 .result-card[data-severity='success'] {
-  border-color: color-mix(in srgb, var(--accent) 38%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border-soft));
 }
 
 .result-card[data-severity='warn'] {
@@ -143,7 +147,7 @@
 }
 
 .result-card[data-severity='neutral'] {
-  border-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(18, 18, 30, 0.05);
 }
 
 .result-header {
@@ -161,7 +165,7 @@
 
 .result-summary {
   margin: 0;
-  color: rgba(255, 255, 255, 0.76);
+  color: var(--text);
   line-height: 1.5;
 }
 
@@ -170,7 +174,7 @@
   padding-left: 18px;
   display: grid;
   gap: 4px;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.92rem;
 }
 
@@ -185,13 +189,13 @@
   font-size: 0.78rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.48);
+  color: var(--text-muted);
 }
 
 .result-details dd {
   margin: 4px 0 0;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
 }
 
 .preview {
@@ -203,18 +207,18 @@
   font-size: 0.78rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.52);
+  color: var(--text-muted);
 }
 
 .preview pre,
 .preview textarea {
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(0, 0, 0, 0.32);
   padding: 14px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
   line-height: 1.5;
   resize: vertical;
   max-height: 360px;
@@ -232,8 +236,8 @@
 
 .image-card {
   padding: 12px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.25);
   font-size: 0.85rem;
 }
@@ -241,12 +245,12 @@
 .image-card strong {
   display: block;
   margin-bottom: 6px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .image-card span {
   display: block;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
   font-size: 0.8rem;
 }
 
@@ -258,8 +262,8 @@
 
 .font-chip {
   padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  background: var(--border-soft);
   border: 1px solid rgba(255, 255, 255, 0.15);
   font-size: 0.88rem;
   font-family: 'JetBrains Mono', monospace;

--- a/src/apps/piano-and-stave/styles.css
+++ b/src/apps/piano-and-stave/styles.css
@@ -1,7 +1,7 @@
 :root {
   --panel-bg: #ffffff;
   --panel-border: rgba(15, 15, 35, 0.1);
-  --panel-shadow: 0 20px 40px rgba(19, 11, 46, 0.08);
+  --panel-shadow: var(--shadow-deep);
   --staff-gap: 20px;
 }
 
@@ -21,7 +21,7 @@
 .panel {
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 28px;
   box-shadow: var(--panel-shadow);
   flex: 1;
@@ -50,7 +50,7 @@
 
 .ghost-button {
   border: 1px solid rgba(15, 15, 35, 0.15);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 8px 16px;
   font-size: 0.9rem;
   background: transparent;
@@ -65,7 +65,7 @@
 
 .staff {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: transparent;
   min-height: 260px;
   overflow: hidden;
@@ -114,7 +114,7 @@
   border-radius: 50% / 55%;
   transform: rotate(-15deg);
   background: var(--accent, #6f6bff);
-  box-shadow: inset -2px -1px 0 rgba(0, 0, 0, 0.3);
+  box-shadow: inset -1px -1px 0 rgba(18, 18, 30, 0.2);
 }
 
 .notation-note .accidental {
@@ -147,7 +147,7 @@
 
 .key-bed {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(145deg, #f5f4ff, #ffffff);
   padding: 16px;
   box-shadow: inset 0 0 0 1px rgba(15, 15, 35, 0.08);
@@ -211,9 +211,9 @@
   position: absolute;
   border-radius: 0 0 6px 6px;
   height: 100%;
-  background: linear-gradient(180deg, #1c1c28, #050507);
+  background: linear-gradient(180deg, #3a3a48, #2a2a34);
   color: #f8f8ff;
-  box-shadow: 0 12px 18px rgba(5, 5, 15, 0.45);
+  box-shadow: 0 2px 6px rgba(16, 16, 28, 0.2);
   pointer-events: auto;
 }
 

--- a/src/apps/piano-and-stave/styles.css
+++ b/src/apps/piano-and-stave/styles.css
@@ -21,7 +21,7 @@
 .panel {
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 24px;
+  border-radius: 0;
   padding: 28px;
   box-shadow: var(--panel-shadow);
   flex: 1;
@@ -50,7 +50,7 @@
 
 .ghost-button {
   border: 1px solid rgba(15, 15, 35, 0.15);
-  border-radius: 999px;
+  border-radius: 0;
   padding: 8px 16px;
   font-size: 0.9rem;
   background: transparent;
@@ -65,8 +65,8 @@
 
 .staff {
   position: relative;
-  border-radius: 20px;
-  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.65), #fdfbff);
+  border-radius: 0;
+  background: transparent;
   min-height: 260px;
   overflow: hidden;
 }
@@ -147,7 +147,7 @@
 
 .key-bed {
   position: relative;
-  border-radius: 18px;
+  border-radius: 0;
   background: linear-gradient(145deg, #f5f4ff, #ffffff);
   padding: 16px;
   box-shadow: inset 0 0 0 1px rgba(15, 15, 35, 0.08);

--- a/src/apps/polyrhythm-drum-sequencer/styles.css
+++ b/src/apps/polyrhythm-drum-sequencer/styles.css
@@ -37,14 +37,14 @@
   font-size: 0.95rem;
   font-weight: 600;
   padding: 10px 18px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease;
 }
 
 .poly-seq .primary-button {
-  background: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.12));
+  background: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
   color: var(--text);
 }
 
@@ -55,13 +55,13 @@
 }
 
 .poly-seq .ghost-button {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(18, 18, 30, 0.05);
   color: var(--text);
 }
 
 .poly-seq .ghost-button:hover:not(:disabled),
 .poly-seq .ghost-button:focus-visible:not(:disabled) {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--border-soft);
 }
 
 .poly-seq button:disabled {
@@ -77,8 +77,8 @@
 .poly-seq .bar-field {
   width: 5.5rem;
   padding: 8px 10px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.25);
   color: var(--text);
   font-family: inherit;
@@ -94,9 +94,9 @@
 
 .poly-seq .sync-readout {
   padding: 12px 16px;
-  border-radius: 14px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.22);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.9rem;
   line-height: 1.55;
   color: var(--text-muted);
@@ -113,9 +113,9 @@
 }
 
 .poly-seq .track-card {
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(12, 14, 28, 0.55);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px 18px 18px;
   display: grid;
   gap: 14px;
@@ -200,9 +200,9 @@
 .poly-seq .step-cell {
   aspect-ratio: 1;
   min-height: 32px;
-  border-radius: 9px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.04);
   cursor: pointer;
   padding: 0;
   transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
@@ -215,7 +215,7 @@
 }
 
 .poly-seq .step-cell.on {
-  background: color-mix(in srgb, var(--track-accent, var(--accent)) 42%, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--track-accent, var(--accent)) 42%, rgba(18, 18, 30, 0.06));
   border-color: color-mix(in srgb, var(--track-accent, var(--accent)) 65%, transparent);
 }
 
@@ -224,10 +224,10 @@
 }
 
 .poly-seq .libraries {
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   padding: 14px 18px;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(18, 18, 30, 0.04);
 }
 
 .poly-seq .libraries summary {

--- a/src/apps/polyrhythm-drum-sequencer/styles.css
+++ b/src/apps/polyrhythm-drum-sequencer/styles.css
@@ -37,7 +37,7 @@
   font-size: 0.95rem;
   font-weight: 600;
   padding: 10px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease;
@@ -77,9 +77,9 @@
 .poly-seq .bar-field {
   width: 5.5rem;
   padding: 8px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(18, 18, 30, 0.05);
   color: var(--text);
   font-family: inherit;
   font-size: 0.95rem;
@@ -94,8 +94,8 @@
 
 .poly-seq .sync-readout {
   padding: 12px 16px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.22);
+  border-radius: var(--radius, 6px);
+  background: rgba(18, 18, 30, 0.05);
   border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.9rem;
   line-height: 1.55;
@@ -113,7 +113,7 @@
 }
 
 .poly-seq .track-card {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px 18px 18px;
@@ -200,7 +200,7 @@
 .poly-seq .step-cell {
   aspect-ratio: 1;
   min-height: 32px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(18, 18, 30, 0.04);
   cursor: pointer;
@@ -224,7 +224,7 @@
 }
 
 .poly-seq .libraries {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   padding: 14px 18px;
   background: rgba(18, 18, 30, 0.04);

--- a/src/apps/qr-code-generator/styles.css
+++ b/src/apps/qr-code-generator/styles.css
@@ -6,12 +6,12 @@
 .qr-field {
   display: grid;
   gap: 8px;
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--text);
 }
 
 .qr-field textarea {
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(10, 13, 24, 0.78);
   padding: 14px 16px;
   font-size: 1rem;
@@ -23,7 +23,7 @@
 
 .qr-field textarea:focus-visible {
   outline: none;
-  border-color: color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-soft));
   box-shadow: 0 0 0 4px rgba(100, 215, 255, 0.12);
 }
 
@@ -31,13 +31,13 @@
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--text);
 }
 
 .field-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .qr-format-group {
@@ -53,7 +53,7 @@
 .qr-format-group legend {
   font-size: 0.92rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   margin-right: 4px;
 }
 
@@ -61,10 +61,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
   padding: 6px 14px;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(18, 18, 30, 0.05);
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
@@ -73,7 +73,7 @@
   appearance: none;
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 2px solid rgba(255, 255, 255, 0.35);
   display: inline-grid;
   place-items: center;
@@ -95,8 +95,8 @@
 
 .chip:hover,
 .chip:focus-within {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.14));
+  background: var(--border-soft);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-soft));
   transform: translateY(-1px);
 }
 
@@ -105,17 +105,17 @@
   align-items: center;
   gap: 10px;
   padding: 10px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(15, 20, 34, 0.68);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--text);
 }
 
 .qr-loading[data-state='ready'] {
   background: rgba(18, 32, 48, 0.7);
-  border-color: rgba(255, 255, 255, 0.16);
-  color: rgba(255, 255, 255, 0.82);
+  border-color: var(--border-soft);
+  color: var(--text);
 }
 
 .spinner {
@@ -151,9 +151,9 @@
 }
 
 .qr-advanced {
-  border-radius: 20px;
+  border-radius: 0;
   background: rgba(14, 16, 29, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
   padding: 12px 16px;
 }
 
@@ -161,7 +161,7 @@
   cursor: pointer;
   font-weight: 600;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
 }
 
 .qr-advanced[open] {
@@ -175,15 +175,15 @@
 .segmented {
   display: inline-flex;
   background: rgba(7, 9, 18, 0.78);
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   overflow: hidden;
 }
 
 .segmented label {
   padding: 8px 12px;
   font-size: 0.88rem;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
   cursor: pointer;
   transition: background 150ms ease, color 150ms ease;
 }
@@ -200,7 +200,7 @@
 }
 
 .segmented label:has(input:checked) {
-  background: color-mix(in srgb, var(--accent) 38%, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--accent) 38%, rgba(18, 18, 30, 0.06));
   color: rgba(16, 32, 48, 0.92);
 }
 
@@ -226,13 +226,13 @@
 
 .range-row input[type='range']::-webkit-slider-runnable-track {
   height: 6px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
+  border-radius: 0;
+  background: var(--border-soft);
 }
 
 .range-value {
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   min-width: 52px;
 }
 
@@ -254,7 +254,7 @@
 .toggle-field .track {
   width: 100%;
   height: 100%;
-  border-radius: 999px;
+  border-radius: 0;
   background: rgba(255, 255, 255, 0.2);
   position: relative;
   transition: background 160ms ease;
@@ -303,8 +303,8 @@
 
 .qr-preview-card {
   position: relative;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(10, 12, 26, 0.78);
   padding: 18px;
   display: grid;
@@ -336,7 +336,7 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid color-mix(in srgb, var(--card-accent) 65%, rgba(255, 255, 255, 0.05));
+  border: 1px solid color-mix(in srgb, var(--card-accent) 65%, rgba(18, 18, 30, 0.05));
   opacity: 0;
   transition: opacity 200ms ease;
 }
@@ -383,13 +383,13 @@
 
 .preview-sub {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .qr-canvas {
   aspect-ratio: 1 / 1;
   width: 100%;
-  border-radius: 18px;
+  border-radius: 0;
   background: linear-gradient(135deg, rgba(252, 253, 255, 0.95), rgba(236, 240, 248, 0.95));
   box-shadow: inset 0 0 0 1px rgba(15, 20, 34, 0.08);
 }
@@ -408,7 +408,7 @@
   display: grid;
   gap: 8px;
   font-size: 0.87rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
 }
 
 .qr-info-row {
@@ -423,18 +423,18 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .qr-info-value {
   justify-self: end;
   text-align: right;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
 }
 
 .preview-footer {
   font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -457,17 +457,17 @@
 
 .qr-status {
   padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(5, 8, 18, 0.6);
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   text-align: center;
 }
 
 .qr-more-options {
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(8, 12, 24, 0.58);
   padding: 14px 18px;
 }
@@ -479,7 +479,7 @@
   cursor: pointer;
   font-weight: 600;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   list-style: none;
   padding: 4px 0;
 }
@@ -491,7 +491,7 @@
 .qr-more-summary::after {
   content: '▾';
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
   transition: transform 160ms ease;
 }
 
@@ -510,7 +510,7 @@
 .qr-more-summary:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(100, 215, 255, 0.28);
-  border-radius: 14px;
+  border-radius: 0;
   padding-inline: 4px;
 }
 

--- a/src/apps/qr-code-generator/styles.css
+++ b/src/apps/qr-code-generator/styles.css
@@ -10,7 +10,7 @@
 }
 
 .qr-field textarea {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(10, 13, 24, 0.78);
   padding: 14px 16px;
@@ -61,7 +61,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   padding: 6px 14px;
   background: rgba(18, 18, 30, 0.05);
@@ -73,7 +73,7 @@
   appearance: none;
   width: 12px;
   height: 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 2px solid rgba(255, 255, 255, 0.35);
   display: inline-grid;
   place-items: center;
@@ -105,7 +105,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(15, 20, 34, 0.68);
   border: 1px solid var(--border-soft);
   font-size: 0.9rem;
@@ -151,7 +151,7 @@
 }
 
 .qr-advanced {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(14, 16, 29, 0.8);
   border: 1px solid var(--border-soft);
   padding: 12px 16px;
@@ -175,7 +175,7 @@
 .segmented {
   display: inline-flex;
   background: rgba(7, 9, 18, 0.78);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   overflow: hidden;
 }
@@ -226,7 +226,7 @@
 
 .range-row input[type='range']::-webkit-slider-runnable-track {
   height: 6px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: var(--border-soft);
 }
 
@@ -254,7 +254,7 @@
 .toggle-field .track {
   width: 100%;
   height: 100%;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(255, 255, 255, 0.2);
   position: relative;
   transition: background 160ms ease;
@@ -303,7 +303,7 @@
 
 .qr-preview-card {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(10, 12, 26, 0.78);
   padding: 18px;
@@ -328,7 +328,7 @@
   outline: none;
   transform: translateY(-3px);
   border-color: color-mix(in srgb, var(--card-accent) 55%, rgba(255, 255, 255, 0.18));
-  box-shadow: 0 18px 35px rgba(20, 24, 46, 0.28);
+  box-shadow: var(--shadow-deep);
 }
 
 .qr-preview-card::after {
@@ -389,7 +389,7 @@
 .qr-canvas {
   aspect-ratio: 1 / 1;
   width: 100%;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(135deg, rgba(252, 253, 255, 0.95), rgba(236, 240, 248, 0.95));
   box-shadow: inset 0 0 0 1px rgba(15, 20, 34, 0.08);
 }
@@ -457,7 +457,7 @@
 
 .qr-status {
   padding: 12px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(5, 8, 18, 0.6);
   font-size: 0.9rem;
@@ -466,7 +466,7 @@
 }
 
 .qr-more-options {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(8, 12, 24, 0.58);
   padding: 14px 18px;
@@ -510,7 +510,7 @@
 .qr-more-summary:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(100, 215, 255, 0.28);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding-inline: 4px;
 }
 

--- a/src/apps/quick-diff/styles.css
+++ b/src/apps/quick-diff/styles.css
@@ -21,7 +21,7 @@
   display: grid;
   gap: 12px;
   padding: clamp(12px, 2vw, 16px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -66,7 +66,7 @@
   position: relative;
   z-index: 1;
   min-height: clamp(200px, 25vh, 280px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px 18px;
@@ -110,7 +110,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.24);
   background: rgba(18, 18, 30, 0.04);
   color: var(--text);
@@ -128,7 +128,7 @@
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.22));
   background: rgba(18, 18, 30, 0.06);
   transform: translateY(-1px);
-  box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
+  box-shadow: var(--shadow-deep);
 }
 
 .diff-summary {
@@ -140,7 +140,7 @@
 .diff-summary .diff-empty {
   margin: 0;
   padding: 18px 20px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px dashed var(--border-soft);
   color: var(--text-muted);
@@ -166,7 +166,7 @@
 .summary-card {
   position: relative;
   padding: 18px 20px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
   display: grid;
@@ -205,7 +205,7 @@
 .diff-results .diff-empty {
   margin: 0;
   padding: 18px 20px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed var(--border-soft);
   background: rgba(18, 18, 30, 0.05);
   color: var(--text);
@@ -221,7 +221,7 @@
   position: relative;
   z-index: 1;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #f6f6f9;
   border: 1px solid var(--border-soft);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
@@ -244,7 +244,7 @@
 .pane-content::-webkit-scrollbar-thumb,
 .diff-input::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.18);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
 }
 
 .diff-pane-grid {
@@ -275,7 +275,7 @@
 .pane-content {
   position: relative;
   z-index: 1;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 18px;

--- a/src/apps/quick-diff/styles.css
+++ b/src/apps/quick-diff/styles.css
@@ -1,11 +1,11 @@
 .quick-diff {
   display: grid;
-  gap: clamp(26px, 4vw, 36px);
+  gap: clamp(14px, 2vw, 20px);
 }
 
 .diff-input-grid {
   display: grid;
-  gap: clamp(18px, 3vw, 26px);
+  gap: clamp(10px, 2vw, 14px);
 }
 
 @media (min-width: 880px) {
@@ -19,29 +19,16 @@
 .diff-card {
   position: relative;
   display: grid;
-  gap: 18px;
-  padding: clamp(20px, 3vw, 28px);
-  border-radius: 26px;
-  background: rgba(11, 14, 27, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  gap: 12px;
+  padding: clamp(12px, 2vw, 16px);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    0 25px 45px rgba(6, 7, 13, 0.55);
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 10px 24px rgba(16, 16, 28, 0.07);
   overflow: hidden;
-}
-
-.diff-input-card::before,
-.diff-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(circle at 10% -15%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 60%);
-  opacity: 0.55;
-}
-
-.diff-card.split-view::before {
-  background: radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent) 40%, transparent) 0%, transparent 65%);
 }
 
 .diff-card-header {
@@ -59,7 +46,7 @@
 
 .diff-card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -71,7 +58,7 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
   z-index: 1;
 }
 
@@ -79,11 +66,11 @@
   position: relative;
   z-index: 1;
   min-height: clamp(200px, 25vh, 280px);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(3, 5, 15, 0.84);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px 18px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: clamp(0.95rem, 1.8vw, 1.05rem);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   line-height: 1.6;
@@ -104,13 +91,13 @@
   justify-content: flex-start;
   gap: 16px;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
   z-index: 1;
 }
 
 .diff-input-meta strong {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .diff-action-bar {
@@ -123,10 +110,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.24);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.88);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text);
   padding: 10px 16px;
   font-weight: 600;
   font-size: 0.92rem;
@@ -139,7 +126,7 @@
 .ghost-button:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.22));
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   transform: translateY(-1px);
   box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
 }
@@ -153,10 +140,10 @@
 .diff-summary .diff-empty {
   margin: 0;
   padding: 18px 20px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px dashed rgba(255, 255, 255, 0.16);
-  color: rgba(255, 255, 255, 0.65);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px dashed var(--border-soft);
+  color: var(--text-muted);
   font-size: 0.95rem;
   text-align: center;
 }
@@ -179,9 +166,9 @@
 .summary-card {
   position: relative;
   padding: 18px 20px;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px solid var(--border-soft);
   display: grid;
   gap: 8px;
   min-height: 120px;
@@ -192,20 +179,20 @@
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .summary-value {
   font-size: clamp(1.6rem, 3vw, 2rem);
   font-weight: 700;
   letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
 }
 
 .summary-card p {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
@@ -218,10 +205,10 @@
 .diff-results .diff-empty {
   margin: 0;
   padding: 18px 20px;
-  border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.68);
+  border-radius: 0;
+  border: 1px dashed var(--border-soft);
+  background: rgba(18, 18, 30, 0.05);
+  color: var(--text);
   text-align: center;
   font-size: 0.95rem;
 }
@@ -234,9 +221,9 @@
   position: relative;
   z-index: 1;
   padding: 18px;
-  border-radius: 18px;
-  background: rgba(3, 5, 15, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: #f6f6f9;
+  border: 1px solid var(--border-soft);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   font-size: clamp(0.9rem, 1.6vw, 1rem);
   line-height: 1.6;
@@ -257,7 +244,7 @@
 .pane-content::-webkit-scrollbar-thumb,
 .diff-input::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.18);
-  border-radius: 16px;
+  border-radius: 0;
 }
 
 .diff-pane-grid {
@@ -282,15 +269,15 @@
   font-size: 0.85rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .pane-content {
   position: relative;
   z-index: 1;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(3, 5, 15, 0.86);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 18px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   font-size: clamp(0.9rem, 1.6vw, 1rem);
@@ -313,7 +300,7 @@
 }
 
 .diff-equal {
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--text);
 }
 
 .diff-insert {
@@ -332,7 +319,7 @@
 .diff-span.ghost {
   opacity: 0.38;
   text-decoration: none;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px var(--border-soft);
 }
 
 .diff-span.ghost[data-diff-ghost='insertion'] {

--- a/src/apps/quick-list-tools/styles.css
+++ b/src/apps/quick-list-tools/styles.css
@@ -7,7 +7,7 @@
   display: grid;
   gap: 14px;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: #ffffff;
 }
@@ -36,7 +36,7 @@
 
 .qlt-field select,
 .qlt-field input[type='text'] {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 10px 12px;
@@ -62,7 +62,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(10, 12, 26, 0.65);
   border: 1px solid var(--border-soft);
   cursor: pointer;
@@ -82,7 +82,7 @@
 
 .qlt-btn {
   border: 1px solid var(--border-soft);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 14px;
   background: rgba(18, 18, 30, 0.06);
   color: var(--text);
@@ -124,7 +124,7 @@
 
 .qlt-panel {
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: #ffffff;
   display: grid;
@@ -152,7 +152,7 @@
 .qlt-textarea {
   min-height: 320px;
   padding: 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
@@ -169,9 +169,9 @@
 
 .qlt-status {
   padding: 12px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.32);
+  background: rgba(18, 18, 30, 0.06);
   color: var(--text);
   font-size: 0.92rem;
 }

--- a/src/apps/quick-list-tools/styles.css
+++ b/src/apps/quick-list-tools/styles.css
@@ -7,9 +7,9 @@
   display: grid;
   gap: 14px;
   padding: 18px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(18, 19, 36, 0.82);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  background: #ffffff;
 }
 
 .qlt-controls-row {
@@ -23,7 +23,7 @@
   display: grid;
   gap: 6px;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--text);
 }
 
 .qlt-field span {
@@ -31,23 +31,23 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   font-size: 0.78rem;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .qlt-field select,
 .qlt-field input[type='text'] {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 10px 12px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   font-size: 0.95rem;
 }
 
 .qlt-field select:focus-visible,
 .qlt-field input[type='text']:focus-visible {
   outline: none;
-  border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.14));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
   box-shadow: 0 0 0 4px rgba(120, 120, 255, 0.12);
 }
 
@@ -62,9 +62,9 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(10, 12, 26, 0.65);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-soft);
   cursor: pointer;
   user-select: none;
 }
@@ -81,27 +81,27 @@
 }
 
 .qlt-btn {
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  border-radius: 0;
   padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.06);
+  color: var(--text);
   font-weight: 700;
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
 }
 
 .qlt-btn.primary {
-  background: color-mix(in srgb, var(--accent) 36%, rgba(255, 255, 255, 0.14));
-  border-color: color-mix(in srgb, var(--accent) 42%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--accent) 36%, var(--border-soft));
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border-soft));
 }
 
 .qlt-btn:hover,
 .qlt-btn:focus-visible {
   outline: none;
   transform: translateY(-1px);
-  background: color-mix(in srgb, var(--accent) 18%, rgba(255, 255, 255, 0.14));
-  border-color: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--accent) 18%, var(--border-soft));
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border-soft));
 }
 
 .qlt-btn:disabled {
@@ -124,9 +124,9 @@
 
 .qlt-panel {
   padding: 18px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(18, 19, 36, 0.82);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  background: #ffffff;
   display: grid;
   gap: 12px;
 }
@@ -146,33 +146,33 @@
 
 .qlt-stats {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .qlt-textarea {
   min-height: 320px;
   padding: 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.92rem;
   line-height: 1.55;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   resize: vertical;
 }
 
 .qlt-textarea:focus-visible {
   outline: none;
-  border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.14));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
 }
 
 .qlt-status {
   padding: 12px 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.32);
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   font-size: 0.92rem;
 }
 

--- a/src/apps/random-name-selector/styles.css
+++ b/src/apps/random-name-selector/styles.css
@@ -13,11 +13,11 @@
 .card {
   position: relative;
   padding: clamp(18px, 3vw, 26px);
-  border-radius: 26px;
-  background: rgba(11, 14, 27, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 25px 45px rgba(6, 7, 13, 0.55);
   overflow: hidden;
   display: grid;
@@ -29,20 +29,12 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(
-    circle at 10% -15%,
-    color-mix(in srgb, var(--accent) 55%, transparent) 0%,
-    transparent 60%
-  );
+  background: transparent;
   opacity: 0.55;
 }
 
 .reveal::before {
-  background: radial-gradient(
-    circle at 100% 0%,
-    color-mix(in srgb, var(--accent) 45%, transparent) 0%,
-    transparent 65%
-  );
+  background: transparent;
 }
 
 .card-header {
@@ -60,7 +52,7 @@
 
 .card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -77,16 +69,16 @@
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .field textarea {
   min-height: clamp(210px, 28vh, 360px);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(3, 5, 15, 0.84);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px 18px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: 1rem;
   line-height: 1.6;
   resize: vertical;
@@ -104,15 +96,15 @@
   gap: 12px;
   flex-wrap: wrap;
   font-size: 0.88rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .field-meta strong {
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
 }
 
 .muted {
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .actions {
@@ -125,7 +117,7 @@
 
 button.primary,
 button.ghost {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 10px 16px;
   font-weight: 700;
   font-size: 0.95rem;
@@ -136,14 +128,14 @@ button.ghost {
 
 button.primary {
   border: 1px solid color-mix(in srgb, var(--accent) 65%, rgba(255, 255, 255, 0.18));
-  background: color-mix(in srgb, var(--accent) 30%, rgba(255, 255, 255, 0.06));
-  color: rgba(255, 255, 255, 0.92);
+  background: color-mix(in srgb, var(--accent) 30%, rgba(18, 18, 30, 0.05));
+  color: var(--text);
 }
 
 button.ghost {
   border: 1px solid rgba(255, 255, 255, 0.24);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.88);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text);
 }
 
 button.primary:hover,
@@ -168,14 +160,14 @@ button.ghost:disabled {
   position: relative;
   z-index: 1;
   padding: clamp(18px, 3vw, 24px);
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(3, 5, 15, 0.88);
   text-align: center;
   font-size: clamp(1.4rem, 3.4vw, 2.2rem);
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: rgba(255, 255, 255, 0.95);
+  color: var(--text);
   min-height: 86px;
   display: grid;
   place-items: center;
@@ -198,14 +190,14 @@ button.ghost:disabled {
 
 .progress-label {
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
 }
 
 .bar {
   height: 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.05);
   overflow: hidden;
 }
 
@@ -216,7 +208,7 @@ button.ghost:disabled {
   background: linear-gradient(
     90deg,
     color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.2)),
-    color-mix(in srgb, var(--accent) 35%, rgba(255, 255, 255, 0.1))
+    color-mix(in srgb, var(--accent) 35%, var(--border-soft))
   );
   transition: width 180ms ease;
 }

--- a/src/apps/random-name-selector/styles.css
+++ b/src/apps/random-name-selector/styles.css
@@ -13,7 +13,7 @@
 .card {
   position: relative;
   padding: clamp(18px, 3vw, 26px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -74,7 +74,7 @@
 
 .field textarea {
   min-height: clamp(210px, 28vh, 360px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px 18px;
@@ -117,7 +117,7 @@
 
 button.primary,
 button.ghost {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 16px;
   font-weight: 700;
   font-size: 0.95rem;
@@ -145,7 +145,7 @@ button.ghost:focus-visible {
   outline: none;
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.22));
-  box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
+  box-shadow: var(--shadow-deep);
 }
 
 button.primary:disabled,
@@ -160,7 +160,7 @@ button.ghost:disabled {
   position: relative;
   z-index: 1;
   padding: clamp(18px, 3vw, 24px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(3, 5, 15, 0.88);
   text-align: center;
@@ -195,7 +195,7 @@ button.ghost:disabled {
 
 .bar {
   height: 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(18, 18, 30, 0.05);
   overflow: hidden;

--- a/src/apps/reverse-engineering-lab/styles.css
+++ b/src/apps/reverse-engineering-lab/styles.css
@@ -11,7 +11,7 @@
 }
 
 .panel {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #ffffff;
   box-shadow:
@@ -57,7 +57,7 @@
 
 .input-label textarea {
   min-height: 280px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   padding: 18px 20px;
   resize: vertical;
@@ -83,7 +83,7 @@
 
 .controls button,
 .controls select {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #ffffff;
   color: inherit;
@@ -132,7 +132,7 @@
 
 .status-line {
   padding: 12px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(9, 11, 24, 0.65);
   font-size: 0.9rem;
@@ -154,7 +154,7 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(8, 9, 20, 0.72);
   font-size: 0.95rem;
@@ -165,7 +165,7 @@
   display: grid;
   gap: 14px;
   padding: clamp(16px, 2.5vw, 26px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(10, 12, 28, 0.8);
   box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
@@ -215,7 +215,7 @@
 .confidence {
   font-size: 0.85rem;
   padding: 2px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: var(--border-soft);
   border: 1px solid rgba(255, 255, 255, 0.18);
   letter-spacing: 0.05em;
@@ -271,9 +271,9 @@
 
 .preview pre,
 .preview textarea {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
-  background: rgba(0, 0, 0, 0.32);
+  background: rgba(18, 18, 30, 0.06);
   padding: 14px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.9rem;
@@ -294,7 +294,7 @@
 }
 
 .result-actions button {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(18, 18, 30, 0.06);
   color: inherit;
@@ -326,8 +326,8 @@
   transform: translateX(-50%);
   white-space: nowrap;
   padding: 6px 12px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.8);
+  border-radius: var(--radius, 6px);
+  background: rgba(22, 22, 30, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.18);
   font-size: 0.8rem;
   letter-spacing: 0.04em;

--- a/src/apps/reverse-engineering-lab/styles.css
+++ b/src/apps/reverse-engineering-lab/styles.css
@@ -11,9 +11,13 @@
 }
 
 .panel {
-  border-radius: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(150deg, rgba(25, 21, 46, 0.92), rgba(15, 12, 30, 0.86));
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #ffffff;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 12px 28px rgba(16, 16, 28, 0.07);
   padding: clamp(22px, 3.5vw, 36px);
   display: grid;
   gap: clamp(18px, 2.5vw, 28px);
@@ -33,7 +37,7 @@
 
 .panel-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.5;
 }
@@ -47,20 +51,20 @@
   font-size: 0.78rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.52);
+  color: var(--text-muted);
   font-weight: 700;
 }
 
 .input-label textarea {
   min-height: 280px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   padding: 18px 20px;
   resize: vertical;
   font-size: 0.95rem;
   line-height: 1.5;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--text);
   background: rgba(6, 8, 20, 0.7);
   transition: border-color 160ms ease, box-shadow 160ms ease;
 }
@@ -79,9 +83,9 @@
 
 .controls button,
 .controls select {
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(17, 18, 38, 0.72);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #ffffff;
   color: inherit;
   padding: 10px 18px;
   font-weight: 600;
@@ -96,12 +100,12 @@
 .controls select:focus-visible {
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent) 32%, rgba(255, 255, 255, 0.2));
-  background: color-mix(in srgb, var(--accent) 18%, rgba(17, 18, 38, 0.82));
+  background: color-mix(in srgb, var(--accent) 18%, #f6f6f9);
   outline: none;
 }
 
 .controls button.primary {
-  background: color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.16));
+  background: color-mix(in srgb, var(--accent) 45%, var(--border-soft));
   border-color: color-mix(in srgb, var(--accent) 60%, rgba(255, 255, 255, 0.4));
 }
 
@@ -128,18 +132,18 @@
 
 .status-line {
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(9, 11, 24, 0.65);
   font-size: 0.9rem;
   letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
 }
 
 .results-meta {
   margin: 0;
   font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .results-list {
@@ -150,21 +154,21 @@
 .empty-state {
   margin: 0;
   padding: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(8, 9, 20, 0.72);
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text);
 }
 
 .result-card {
   display: grid;
   gap: 14px;
   padding: clamp(16px, 2.5vw, 26px);
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(10, 12, 28, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.03);
   position: relative;
   overflow: hidden;
 }
@@ -184,7 +188,7 @@
 }
 
 .result-card[data-severity='success'] {
-  border-color: color-mix(in srgb, var(--accent) 38%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border-soft));
 }
 
 .result-card[data-severity='warn'] {
@@ -192,7 +196,7 @@
 }
 
 .result-card[data-severity='neutral'] {
-  border-color: rgba(255, 255, 255, 0.06);
+  border-color: rgba(18, 18, 30, 0.05);
 }
 
 .result-header {
@@ -211,8 +215,8 @@
 .confidence {
   font-size: 0.85rem;
   padding: 2px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  background: var(--border-soft);
   border: 1px solid rgba(255, 255, 255, 0.18);
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -220,7 +224,7 @@
 
 .result-summary {
   margin: 0;
-  color: rgba(255, 255, 255, 0.76);
+  color: var(--text);
   line-height: 1.5;
 }
 
@@ -229,7 +233,7 @@
   padding-left: 18px;
   display: grid;
   gap: 4px;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.92rem;
 }
 
@@ -244,13 +248,13 @@
   font-size: 0.78rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.48);
+  color: var(--text-muted);
 }
 
 .result-details dd {
   margin: 4px 0 0;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
 }
 
 .preview {
@@ -262,18 +266,18 @@
   font-size: 0.78rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.52);
+  color: var(--text-muted);
 }
 
 .preview pre,
 .preview textarea {
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(0, 0, 0, 0.32);
   padding: 14px;
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
   line-height: 1.5;
   resize: vertical;
   max-height: 360px;
@@ -290,9 +294,9 @@
 }
 
 .result-actions button {
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   color: inherit;
   padding: 8px 16px;
   font-size: 0.9rem;
@@ -305,7 +309,7 @@
 .result-actions button:hover,
 .result-actions button:focus-visible {
   transform: translateY(-1px);
-  background: color-mix(in srgb, var(--accent) 24%, rgba(255, 255, 255, 0.12));
+  background: color-mix(in srgb, var(--accent) 24%, var(--border-soft));
   border-color: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.22));
   outline: none;
 }
@@ -322,12 +326,12 @@
   transform: translateX(-50%);
   white-space: nowrap;
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.18);
   font-size: 0.8rem;
   letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.88);
+  color: var(--text);
   opacity: 0;
   pointer-events: none;
   animation: toast-pop 1.5s ease;

--- a/src/apps/roman-numeral-translator/styles.css
+++ b/src/apps/roman-numeral-translator/styles.css
@@ -26,11 +26,11 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 26px);
-  border-radius: 26px;
-  background: rgba(11, 14, 27, 0.74);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 20px 35px rgba(12, 7, 2, 0.35);
   overflow: hidden;
 }
@@ -40,16 +40,16 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 10% -20%, color-mix(in srgb, var(--accent) 65%, transparent) 0%, transparent 55%);
+  background: transparent;
   opacity: 0.5;
 }
 
 .translator-card.history-card::before {
-  background: radial-gradient(circle at -10% 10%, color-mix(in srgb, var(--accent) 40%, transparent) 0%, transparent 60%);
+  background: transparent;
 }
 
 .translator-card.reference-card::before {
-  background: radial-gradient(circle at 110% 0%, color-mix(in srgb, var(--accent) 50%, transparent) 0%, transparent 60%);
+  background: transparent;
 }
 
 .card-header {
@@ -63,7 +63,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .card-header h2 {
@@ -74,7 +74,7 @@
 
 .card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -95,16 +95,16 @@
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: 0.01em;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .field-input {
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(7, 9, 18, 0.78);
   padding: 14px 16px;
   font-size: 1.05rem;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
@@ -122,7 +122,7 @@
 .field-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .primary-btn {
@@ -131,12 +131,12 @@
   align-items: center;
   gap: 8px;
   padding: 12px 18px;
-  border-radius: 999px;
+  border-radius: 0;
   border: none;
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.1)), color-mix(in srgb, var(--accent) 55%, rgba(0, 0, 0, 0.2)));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 75%, var(--border-soft)), color-mix(in srgb, var(--accent) 55%, rgba(0, 0, 0, 0.2)));
   color: rgba(17, 18, 26, 0.95);
   cursor: pointer;
   transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
@@ -153,7 +153,7 @@
 .field-error {
   margin: 0;
   padding: 10px 12px;
-  border-radius: 14px;
+  border-radius: 0;
   font-size: 0.88rem;
   line-height: 1.5;
   color: rgba(255, 225, 232, 0.92);
@@ -166,9 +166,9 @@
   display: grid;
   gap: 12px;
   padding: 18px 18px 16px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px solid var(--border-soft);
   transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
   z-index: 1;
 }
@@ -177,7 +177,7 @@
   border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.15));
   box-shadow:
     0 20px 30px rgba(240, 140, 74, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    inset 0 1px 0 var(--border-soft);
 }
 
 .result-block[data-state='error'] {
@@ -189,7 +189,7 @@
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .result-value {
@@ -202,7 +202,7 @@
   display: grid;
   gap: 10px;
   padding-top: 4px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid rgba(18, 18, 30, 0.06);
 }
 
 .breakdown-wrapper[data-state='empty'] {
@@ -213,7 +213,7 @@
   font-size: 0.82rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .breakdown-list {
@@ -229,12 +229,12 @@
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 8px 12px;
   background: rgba(9, 12, 24, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--border-soft);
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.86);
+  color: var(--text);
 }
 
 .chip-symbol {
@@ -244,7 +244,7 @@
 
 .chip-value {
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
 }
 
 .history-list {
@@ -267,9 +267,9 @@
   gap: 12px;
   align-items: center;
   padding: 12px 14px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(8, 11, 22, 0.76);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
 }
 
 .history-value {
@@ -280,7 +280,7 @@
 }
 
 .history-value.from {
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--text);
 }
 
 .history-value.to {
@@ -290,7 +290,7 @@
 .history-arrow {
   justify-self: center;
   font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .history-meta {
@@ -298,17 +298,17 @@
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .empty-state {
   margin: 0;
   padding: 12px 14px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(12, 14, 26, 0.65);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--text);
   z-index: 1;
 }
 
@@ -329,9 +329,9 @@
   display: grid;
   gap: 12px;
   padding: 14px;
-  border-radius: 18px;
+  border-radius: 0;
   background: rgba(8, 10, 20, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--border-soft);
 }
 
 .reference-column h3 {
@@ -354,9 +354,9 @@
   align-items: center;
   font-size: 0.95rem;
   padding: 8px 10px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px solid var(--border-soft);
 }
 
 .ref-roman {
@@ -365,7 +365,7 @@
 }
 
 .ref-value {
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   font-weight: 500;
 }
 
@@ -373,7 +373,7 @@
   position: relative;
   margin: 0;
   padding: 12px 0 0;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
   font-size: 0.88rem;
   line-height: 1.6;
   z-index: 1;

--- a/src/apps/roman-numeral-translator/styles.css
+++ b/src/apps/roman-numeral-translator/styles.css
@@ -26,7 +26,7 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 26px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -99,7 +99,7 @@
 }
 
 .field-input {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(7, 9, 18, 0.78);
   padding: 14px 16px;
@@ -131,12 +131,12 @@
   align-items: center;
   gap: 8px;
   padding: 12px 18px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: none;
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 75%, var(--border-soft)), color-mix(in srgb, var(--accent) 55%, rgba(0, 0, 0, 0.2)));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 75%, var(--border-soft)), color-mix(in srgb, var(--accent) 55%, rgba(18, 18, 30, 0.08)));
   color: rgba(17, 18, 26, 0.95);
   cursor: pointer;
   transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
@@ -153,7 +153,7 @@
 .field-error {
   margin: 0;
   padding: 10px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   font-size: 0.88rem;
   line-height: 1.5;
   color: rgba(255, 225, 232, 0.92);
@@ -166,7 +166,7 @@
   display: grid;
   gap: 12px;
   padding: 18px 18px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
   transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
@@ -229,7 +229,7 @@
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 8px 12px;
   background: rgba(9, 12, 24, 0.78);
   border: 1px solid var(--border-soft);
@@ -267,7 +267,7 @@
   gap: 12px;
   align-items: center;
   padding: 12px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(8, 11, 22, 0.76);
   border: 1px solid var(--border-soft);
 }
@@ -304,7 +304,7 @@
 .empty-state {
   margin: 0;
   padding: 12px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(12, 14, 26, 0.65);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   font-size: 0.9rem;
@@ -329,7 +329,7 @@
   display: grid;
   gap: 12px;
   padding: 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(8, 10, 20, 0.7);
   border: 1px solid var(--border-soft);
 }
@@ -354,7 +354,7 @@
   align-items: center;
   font-size: 0.95rem;
   padding: 8px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
 }

--- a/src/apps/scan-vector-lab/styles.css
+++ b/src/apps/scan-vector-lab/styles.css
@@ -1,8 +1,8 @@
 :root {
-  --panel-bg: #111827;
-  --panel-border: rgba(255, 255, 255, 0.08);
-  --text-muted: #9ba3b4;
-  --chip-bg: rgba(255, 255, 255, 0.08);
+  --panel-bg: #ffffff;
+  --panel-border: rgba(18, 18, 30, 0.12);
+  --text-muted: rgba(20, 20, 26, 0.58);
+  --chip-bg: rgba(18, 18, 30, 0.06);
   --chip-success: #2dd4bf;
   --chip-danger: #f87171;
   --chip-info: #60a5fa;
@@ -18,12 +18,14 @@
 }
 
 .panel-card {
-  background: linear-gradient(150deg, rgba(12, 16, 26, 0.9), rgba(10, 13, 22, 0.85));
+  background: #ffffff;
   border: 1px solid var(--panel-border);
-  border-radius: 28px;
+  border-radius: 0;
   padding: clamp(1.5rem, 2vw, 2.5rem);
-  box-shadow: 0 35px 80px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(18px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 14px 32px rgba(16, 16, 28, 0.08);
 }
 
 .panel-card header h2 {
@@ -55,8 +57,8 @@
 .sheet-controls input {
   font: inherit;
   padding: 0.5rem 0.75rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(15, 19, 30, 0.75);
   color: #fff;
   transition: border-color 0.2s ease;
@@ -71,9 +73,9 @@
 .sheet-preview {
   width: min(100%, 480px);
   height: auto;
-  border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0;
+  border: 1px dashed var(--border-soft);
+  background: rgba(18, 18, 30, 0.03);
   margin: 0 auto 1.5rem;
   display: block;
 }
@@ -87,8 +89,8 @@
 
 .sheet-summary {
   margin-top: 1.25rem;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 16px;
+  background: rgba(18, 18, 30, 0.04);
+  border-radius: 0;
   padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
@@ -103,11 +105,11 @@
 
 .capture-stage {
   position: relative;
-  border-radius: 24px;
+  border-radius: 0;
   overflow: hidden;
   aspect-ratio: 16 / 9;
   background: rgba(8, 11, 19, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(18, 18, 30, 0.05);
   margin-bottom: 1rem;
 }
 
@@ -133,7 +135,7 @@
   justify-content: center;
   text-align: center;
   padding: 1.5rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
   font-weight: 600;
   letter-spacing: 0.02em;
   backdrop-filter: blur(4px);
@@ -156,7 +158,7 @@
 
 .status-chip {
   padding: 0.35rem 0.85rem;
-  border-radius: 999px;
+  border-radius: 0;
   font-size: 0.82rem;
   letter-spacing: 0.02em;
   background: var(--chip-bg);
@@ -186,8 +188,8 @@
 }
 
 .metric {
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 16px;
+  background: rgba(18, 18, 30, 0.04);
+  border-radius: 0;
   padding: 0.75rem 1rem;
   display: flex;
   flex-direction: column;
@@ -205,8 +207,8 @@
 }
 
 .detections {
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 16px;
+  background: rgba(18, 18, 30, 0.04);
+  border-radius: 0;
   padding: 0.75rem;
   min-height: 62px;
   display: flex;
@@ -215,7 +217,7 @@
 }
 
 .tag-pill {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 0.35rem 0.8rem;
   background: rgba(76, 201, 240, 0.12);
   font-size: 0.82rem;
@@ -233,8 +235,8 @@
 .result-canvas {
   width: 100%;
   background: rgba(0, 0, 0, 0.35);
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   display: block;
   margin-bottom: 1.25rem;
 }
@@ -266,8 +268,8 @@
 }
 
 .contour-list {
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.04);
   padding: 1rem;
   min-height: 90px;
   margin-bottom: 1rem;
@@ -281,7 +283,7 @@
   justify-content: space-between;
   font-size: 0.9rem;
   gap: 0.5rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
 }
 
 .contour-row span {
@@ -297,7 +299,7 @@
 .secondary-button,
 .ghost-button {
   font: inherit;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 0.65rem 1.4rem;
   border: 1px solid transparent;
   cursor: pointer;
@@ -311,19 +313,19 @@
 
 .primary-button.ghost {
   background: transparent;
-  border-color: rgba(255, 255, 255, 0.2);
+  border-color: var(--text-muted);
   color: #fff;
 }
 
 .secondary-button {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.05);
+  border-color: rgba(18, 18, 30, 0.06);
   color: #fff;
 }
 
 .ghost-button {
   background: transparent;
-  border-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(18, 18, 30, 0.06);
   color: var(--text-muted);
 }
 

--- a/src/apps/scan-vector-lab/styles.css
+++ b/src/apps/scan-vector-lab/styles.css
@@ -20,7 +20,7 @@
 .panel-card {
   background: #ffffff;
   border: 1px solid var(--panel-border);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: clamp(1.5rem, 2vw, 2.5rem);
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.96) inset,
@@ -57,7 +57,7 @@
 .sheet-controls input {
   font: inherit;
   padding: 0.5rem 0.75rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(15, 19, 30, 0.75);
   color: #fff;
@@ -73,7 +73,7 @@
 .sheet-preview {
   width: min(100%, 480px);
   height: auto;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed var(--border-soft);
   background: rgba(18, 18, 30, 0.03);
   margin: 0 auto 1.5rem;
@@ -90,7 +90,7 @@
 .sheet-summary {
   margin-top: 1.25rem;
   background: rgba(18, 18, 30, 0.04);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
@@ -105,7 +105,7 @@
 
 .capture-stage {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   overflow: hidden;
   aspect-ratio: 16 / 9;
   background: rgba(8, 11, 19, 0.85);
@@ -158,7 +158,7 @@
 
 .status-chip {
   padding: 0.35rem 0.85rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   font-size: 0.82rem;
   letter-spacing: 0.02em;
   background: var(--chip-bg);
@@ -189,7 +189,7 @@
 
 .metric {
   background: rgba(18, 18, 30, 0.04);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.75rem 1rem;
   display: flex;
   flex-direction: column;
@@ -208,7 +208,7 @@
 
 .detections {
   background: rgba(18, 18, 30, 0.04);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.75rem;
   min-height: 62px;
   display: flex;
@@ -217,7 +217,7 @@
 }
 
 .tag-pill {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.35rem 0.8rem;
   background: rgba(76, 201, 240, 0.12);
   font-size: 0.82rem;
@@ -234,8 +234,8 @@
 
 .result-canvas {
   width: 100%;
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: 0;
+  background: rgba(18, 18, 30, 0.06);
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   display: block;
   margin-bottom: 1.25rem;
@@ -268,7 +268,7 @@
 }
 
 .contour-list {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.04);
   padding: 1rem;
   min-height: 90px;
@@ -299,7 +299,7 @@
 .secondary-button,
 .ghost-button {
   font: inherit;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.65rem 1.4rem;
   border: 1px solid transparent;
   cursor: pointer;
@@ -308,7 +308,7 @@
 
 .primary-button {
   background: linear-gradient(120deg, #ff914d, #fb6f92);
-  color: #05070d;
+  color: var(--text);
 }
 
 .primary-button.ghost {

--- a/src/apps/score-taking-app/styles.css
+++ b/src/apps/score-taking-app/styles.css
@@ -1,6 +1,6 @@
 :root {
   --score-surface: rgba(6, 9, 25, 0.86);
-  --score-border: rgba(255, 255, 255, 0.1);
+  --score-border: var(--border-soft);
   --score-radius: 24px;
 }
 
@@ -30,7 +30,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 10% -20%, color-mix(in srgb, var(--accent) 35%, transparent) 0%, transparent 65%);
+  background: transparent;
   opacity: 0.4;
   pointer-events: none;
 }
@@ -45,7 +45,7 @@
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.72rem;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .card-header h2,
@@ -58,7 +58,7 @@
 .card-header p,
 .score-table-header p {
   margin: 6px 0 0;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text);
   line-height: 1.6;
 }
 
@@ -71,10 +71,10 @@
 
 .player-input {
   width: 100%;
-  border-radius: 18px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(3, 4, 14, 0.85);
-  color: rgba(255, 255, 255, 0.95);
+  background: #f6f6f9;
+  color: var(--text);
   padding: 14px 16px;
   font-size: 1rem;
   line-height: 1.4;
@@ -90,8 +90,8 @@
 
 .primary-button {
   border: none;
-  border-radius: 16px;
-  background: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.08));
+  border-radius: 0;
+  background: color-mix(in srgb, var(--accent) 75%, rgba(18, 18, 30, 0.06));
   color: #07040f;
   font-weight: 700;
   padding: 12px 20px;
@@ -121,7 +121,7 @@
 .form-hint {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .form-hint[data-state='error'] {
@@ -133,15 +133,15 @@
   flex-wrap: wrap;
   gap: 10px;
   padding: 12px;
-  border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0;
+  border: 1px dashed var(--border-soft);
+  background: rgba(18, 18, 30, 0.03);
   min-height: 56px;
 }
 
 .player-list.player-list-empty {
   justify-content: center;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
   font-size: 0.95rem;
   text-align: center;
 }
@@ -155,9 +155,9 @@
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.05);
   font-size: 0.9rem;
   letter-spacing: 0.01em;
 }
@@ -165,13 +165,13 @@
 .player-chip-index {
   width: 26px;
   height: 26px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .player-chip-name {
@@ -220,16 +220,16 @@
 
 .totals-strip::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 999px;
+  border-radius: 0;
 }
 
 .totals-strip[data-state='empty'] {
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
 .totals-empty {
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .total-badge {
@@ -237,9 +237,9 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.04);
   font-size: 0.85rem;
   white-space: nowrap;
 }
@@ -256,10 +256,10 @@
 .score-empty {
   margin: 0;
   padding: 16px;
-  border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.03);
-  color: rgba(255, 255, 255, 0.7);
+  border-radius: 0;
+  border: 1px dashed var(--border-soft);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text-muted);
   text-align: center;
   font-size: 0.95rem;
 }
@@ -272,8 +272,8 @@
   position: relative;
   width: 100%;
   overflow-x: auto;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 4, 12, 0.82);
   padding: 6px 0;
 }
@@ -323,8 +323,8 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 14px 12px;
-  background: rgba(255, 255, 255, 0.04);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.04);
+  border-bottom: 1px solid rgba(18, 18, 30, 0.06);
   white-space: nowrap;
 }
 
@@ -337,7 +337,7 @@
 }
 
 .score-table tbody th {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(18, 18, 30, 0.04);
   text-align: left;
   padding: 10px 12px;
   font-weight: 600;
@@ -346,7 +346,7 @@
 
 .score-table td {
   padding: 10px 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid rgba(18, 18, 30, 0.05);
 }
 
 .score-table tbody tr:nth-of-type(even) {
@@ -358,8 +358,8 @@
   position: sticky;
   top: 0;
   background: color-mix(in srgb, var(--accent) 8%, rgba(3, 4, 14, 0.95));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--border-soft);
+  box-shadow: inset 0 -1px 0 rgba(18, 18, 30, 0.06);
   font-weight: 700;
 }
 
@@ -384,10 +384,10 @@
 .row-label-input,
 .score-input {
   width: 100%;
-  border-radius: 16px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.02);
-  color: rgba(255, 255, 255, 0.95);
+  background: rgba(18, 18, 30, 0.03);
+  color: var(--text);
   padding: 12px 14px;
   font-size: 1rem;
   transition: border-color 120ms ease, box-shadow 120ms ease;
@@ -472,7 +472,7 @@
 
   .score-table tbody tr {
     padding: 16px 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(18, 18, 30, 0.06);
   }
 
   .score-table tbody tr:last-child {
@@ -495,7 +495,7 @@
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--text-muted);
     margin-bottom: 4px;
   }
 

--- a/src/apps/score-taking-app/styles.css
+++ b/src/apps/score-taking-app/styles.css
@@ -21,7 +21,7 @@
   border-radius: var(--score-radius);
   background: var(--score-surface);
   border: 1px solid var(--score-border);
-  box-shadow: 0 25px 45px rgba(3, 4, 12, 0.55);
+  box-shadow: var(--shadow-deep);
   overflow: hidden;
   backdrop-filter: blur(18px);
 }
@@ -71,7 +71,7 @@
 
 .player-input {
   width: 100%;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: #f6f6f9;
   color: var(--text);
@@ -90,7 +90,7 @@
 
 .primary-button {
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: color-mix(in srgb, var(--accent) 75%, rgba(18, 18, 30, 0.06));
   color: #07040f;
   font-weight: 700;
@@ -114,7 +114,7 @@
 .primary-button:not(:disabled):hover,
 .primary-button:not(:disabled):focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 18px 30px rgba(5, 6, 15, 0.45);
+  box-shadow: var(--shadow-deep);
   filter: brightness(1.07);
 }
 
@@ -133,7 +133,7 @@
   flex-wrap: wrap;
   gap: 10px;
   padding: 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed var(--border-soft);
   background: rgba(18, 18, 30, 0.03);
   min-height: 56px;
@@ -155,7 +155,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(18, 18, 30, 0.05);
   font-size: 0.9rem;
@@ -165,7 +165,7 @@
 .player-chip-index {
   width: 26px;
   height: 26px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   display: inline-flex;
   align-items: center;
@@ -220,7 +220,7 @@
 
 .totals-strip::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
 }
 
 .totals-strip[data-state='empty'] {
@@ -237,7 +237,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: rgba(18, 18, 30, 0.04);
   font-size: 0.85rem;
@@ -256,7 +256,7 @@
 .score-empty {
   margin: 0;
   padding: 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed var(--border-soft);
   background: rgba(18, 18, 30, 0.04);
   color: var(--text-muted);
@@ -272,7 +272,7 @@
   position: relative;
   width: 100%;
   overflow-x: auto;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(18, 18, 30, 0.06);
   background: rgba(2, 4, 12, 0.82);
   padding: 6px 0;
@@ -384,7 +384,7 @@
 .row-label-input,
 .score-input {
   width: 100%;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(18, 18, 30, 0.03);
   color: var(--text);

--- a/src/apps/screen-shape-measurement-tool/styles.css
+++ b/src/apps/screen-shape-measurement-tool/styles.css
@@ -44,11 +44,11 @@
 .measurement-card {
   background: rgba(14, 16, 32, 0.7);
   border: 1px solid rgba(18, 18, 30, 0.06);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 18px;
   display: grid;
   gap: 14px;
-  box-shadow: 0 22px 40px -34px rgba(0, 0, 0, 0.65);
+  box-shadow: var(--shadow-deep);
 }
 
 .card-header h3 {
@@ -78,9 +78,9 @@
 .unit-select {
   min-width: 96px;
   padding: 8px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(18, 18, 30, 0.05);
   color: inherit;
   font-size: 0.95rem;
 }
@@ -115,7 +115,7 @@
   border: 1px solid var(--border-soft);
   background: rgba(18, 18, 30, 0.06);
   color: inherit;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 16px;
   font-weight: 600;
   cursor: pointer;
@@ -137,7 +137,7 @@
 
 .calibration-line {
   height: 6px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.25), var(--accent));
   position: relative;
 }
@@ -188,9 +188,9 @@ input[type='number'] {
   font-family: inherit;
   font-size: 0.95rem;
   padding: 8px 10px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(18, 18, 30, 0.04);
   color: inherit;
   width: 100%;
 }
@@ -252,7 +252,7 @@ input[type='range'] {
 .tool-preview {
   position: relative;
   min-height: 180px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px dashed var(--border-soft);
   background: rgba(8, 10, 22, 0.7);
   overflow: auto;
@@ -279,7 +279,7 @@ input[type='range'] {
   z-index: 1;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(92, 247, 193, 0.5));
   border: 1px solid rgba(255, 255, 255, 0.35);
-  box-shadow: 0 14px 24px -18px rgba(0, 0, 0, 0.7);
+  box-shadow: var(--shadow-deep);
 }
 
 .shape-circle {
@@ -299,7 +299,7 @@ input[type='range'] {
 }
 
 .shape-line {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.35), var(--accent));
 }
 

--- a/src/apps/screen-shape-measurement-tool/styles.css
+++ b/src/apps/screen-shape-measurement-tool/styles.css
@@ -43,8 +43,8 @@
 
 .measurement-card {
   background: rgba(14, 16, 32, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 20px;
+  border: 1px solid rgba(18, 18, 30, 0.06);
+  border-radius: 0;
   padding: 18px;
   display: grid;
   gap: 14px;
@@ -78,8 +78,8 @@
 .unit-select {
   min-width: 96px;
   padding: 8px 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.25);
   color: inherit;
   font-size: 0.95rem;
@@ -112,10 +112,10 @@
 }
 
 .ghost-button {
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-soft);
+  background: rgba(18, 18, 30, 0.06);
   color: inherit;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 10px 16px;
   font-weight: 600;
   cursor: pointer;
@@ -126,7 +126,7 @@
 .ghost-button:hover,
 .ghost-button:focus-visible {
   transform: translateY(-2px);
-  background: color-mix(in srgb, var(--accent) 25%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--accent) 25%, var(--border-soft));
   outline: none;
 }
 
@@ -137,7 +137,7 @@
 
 .calibration-line {
   height: 6px;
-  border-radius: 999px;
+  border-radius: 0;
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.25), var(--accent));
   position: relative;
 }
@@ -188,8 +188,8 @@ input[type='number'] {
   font-family: inherit;
   font-size: 0.95rem;
   padding: 8px 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   background: rgba(0, 0, 0, 0.2);
   color: inherit;
   width: 100%;
@@ -252,8 +252,8 @@ input[type='range'] {
 .tool-preview {
   position: relative;
   min-height: 180px;
-  border-radius: 16px;
-  border: 1px dashed rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  border: 1px dashed var(--border-soft);
   background: rgba(8, 10, 22, 0.7);
   overflow: auto;
   display: flex;
@@ -267,8 +267,8 @@ input[type='range'] {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+    linear-gradient(rgba(18, 18, 30, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 18, 30, 0.05) 1px, transparent 1px);
   background-size: 24px 24px;
   opacity: 0.4;
   pointer-events: none;
@@ -299,7 +299,7 @@ input[type='range'] {
 }
 
 .shape-line {
-  border-radius: 999px;
+  border-radius: 0;
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.35), var(--accent));
 }
 

--- a/src/apps/shared/appShell.js
+++ b/src/apps/shared/appShell.js
@@ -21,7 +21,13 @@ export function createAppShell({ title, description, accent, status }) {
   const backLink = document.createElement('a');
   backLink.href = '../../';
   backLink.className = 'back-link';
-  backLink.textContent = '← Back to the hub';
+  backLink.setAttribute('aria-label', 'Back to the hub');
+  backLink.innerHTML = `
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M14 6l-6 6 6 6" stroke="currentColor" stroke-width="2.2" stroke-linecap="square" stroke-linejoin="miter"/>
+    </svg>
+    <span class="visually-hidden">Back to the hub</span>
+  `;
   header.appendChild(backLink);
 
   const h1 = document.createElement('h1');

--- a/src/apps/slope-intercept-calculator/styles.css
+++ b/src/apps/slope-intercept-calculator/styles.css
@@ -14,11 +14,11 @@
   display: grid;
   gap: 16px;
   padding: clamp(18px, 3vw, 24px);
-  border-radius: 24px;
-  background: rgba(11, 14, 27, 0.74);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 20px 35px rgba(12, 7, 2, 0.35);
 }
 
@@ -35,7 +35,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .calc-card-header h2 {
@@ -46,7 +46,7 @@
 
 .calc-card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -68,9 +68,9 @@
 }
 
 .point-fieldset {
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 14px;
   display: grid;
   gap: 12px;
@@ -79,7 +79,7 @@
 .point-fieldset legend {
   padding: 0 6px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text);
 }
 
 .field-row {
@@ -91,7 +91,7 @@
 .field-group {
   display: grid;
   gap: 6px;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
@@ -99,21 +99,21 @@
   font-size: 0.78rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .field-input {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 10px 12px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   font-size: 0.98rem;
 }
 
 .field-input:focus-visible {
   outline: none;
-  border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.14));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
   box-shadow: 0 0 0 4px rgba(120, 120, 255, 0.12);
 }
 
@@ -124,7 +124,7 @@
 
 .calc-helper {
   margin: 0;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
@@ -135,36 +135,36 @@
 }
 
 .action-button {
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  border-radius: 0;
   padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.06);
+  color: var(--text);
   font-weight: 600;
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
 }
 
 .action-button.primary {
-  background: color-mix(in srgb, var(--accent) 36%, rgba(255, 255, 255, 0.14));
-  border-color: color-mix(in srgb, var(--accent) 42%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--accent) 36%, var(--border-soft));
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border-soft));
 }
 
 .action-button.ghost {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(18, 18, 30, 0.04);
 }
 
 .action-button:hover,
 .action-button:focus-visible {
   outline: none;
   transform: translateY(-1px);
-  background: color-mix(in srgb, var(--accent) 18%, rgba(255, 255, 255, 0.14));
-  border-color: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.14));
+  background: color-mix(in srgb, var(--accent) 18%, var(--border-soft));
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border-soft));
 }
 
 .result-status {
   margin: 0;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--text-muted);
   font-size: 0.95rem;
 }
 
@@ -180,9 +180,9 @@
 
 .result-item {
   padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   display: grid;
   gap: 6px;
 }
@@ -191,7 +191,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .result-value {
@@ -201,9 +201,9 @@
 
 .equation-block {
   padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(10, 12, 26, 0.7);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   display: grid;
   gap: 6px;
 }
@@ -212,7 +212,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
 }
 
 .equation-value {
@@ -224,11 +224,11 @@
 .equation-hint {
   margin: 0;
   font-size: 0.86rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .point-summary {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }

--- a/src/apps/slope-intercept-calculator/styles.css
+++ b/src/apps/slope-intercept-calculator/styles.css
@@ -14,7 +14,7 @@
   display: grid;
   gap: 16px;
   padding: clamp(18px, 3vw, 24px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -68,7 +68,7 @@
 }
 
 .point-fieldset {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 14px;
@@ -103,7 +103,7 @@
 }
 
 .field-input {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 10px 12px;
@@ -136,7 +136,7 @@
 
 .action-button {
   border: 1px solid var(--border-soft);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 10px 14px;
   background: rgba(18, 18, 30, 0.06);
   color: var(--text);
@@ -180,7 +180,7 @@
 
 .result-item {
   padding: 12px 14px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   display: grid;
@@ -201,7 +201,7 @@
 
 .equation-block {
   padding: 14px 16px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   display: grid;

--- a/src/apps/sokoban-vault/styles.css
+++ b/src/apps/sokoban-vault/styles.css
@@ -2,7 +2,7 @@
   --vault-bg: #0b132b;
   --vault-panel: #131e3a;
   --vault-panel-alt: #18264b;
-  --vault-border: rgba(255, 255, 255, 0.08);
+  --vault-border: rgba(18, 18, 30, 0.06);
   --vault-text: #f5f7ff;
   --vault-muted: rgba(245, 247, 255, 0.7);
   --crate: #fcd34d;
@@ -47,8 +47,8 @@
 
 .meta-chip {
   padding: 0.15rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.06);
   font-size: 0.85rem;
   color: var(--vault-muted);
 }
@@ -64,7 +64,7 @@
   padding: 0.9rem;
   border-radius: 0.75rem;
   border: 1px solid var(--vault-border);
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(18, 18, 30, 0.03);
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -84,7 +84,7 @@
   margin-top: 1.5rem;
   padding: 1rem;
   border-radius: 1rem;
-  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.05), rgba(10, 14, 25, 0.9));
+  background: transparent;
   border: 1px solid var(--vault-border);
   overflow: hidden;
 }
@@ -120,13 +120,13 @@
   aspect-ratio: 1 / 1;
   border-radius: 0.45rem;
   position: relative;
-  background: rgba(255, 255, 255, 0.02);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  background: rgba(18, 18, 30, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.04);
 }
 
 .tile[data-tile='wall'] {
   background: linear-gradient(135deg, #1c2541, #0b132b);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.06);
 }
 
 .tile[data-tile='target'] {
@@ -207,11 +207,11 @@
 .pad-button {
   border-radius: 1rem;
   border: 1px solid var(--vault-border);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   color: var(--vault-text);
   font-size: 1.25rem;
   padding: 0.8rem 0;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.05);
 }
 
 .pad-button:active {
@@ -237,7 +237,7 @@
 
 .ghost-button,
 .primary-button {
-  border-radius: 999px;
+  border-radius: 0;
   padding: 0.5rem 1.3rem;
   border: 1px solid var(--vault-border);
   background: transparent;
@@ -248,7 +248,7 @@
 
 .ghost-button:hover,
 .primary-button:hover {
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--text-muted);
   transform: translateY(-1px);
 }
 
@@ -263,7 +263,7 @@
   font-size: 0.95rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--vault-border);
   color: var(--vault-muted);
 }
@@ -278,7 +278,7 @@
 
 .helper-card {
   margin-top: 1.5rem;
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(18, 18, 30, 0.04);
   border-radius: 0.9rem;
   padding: 1rem;
   border: 1px solid var(--vault-border);
@@ -319,7 +319,7 @@
 .selector-header input,
 .selector-header select {
   width: 100%;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid var(--vault-border);
   background: rgba(0, 0, 0, 0.2);
   color: var(--vault-text);
@@ -327,7 +327,7 @@
 }
 
 .selector-header input::placeholder {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
 }
 
 .progress-badge {
@@ -335,7 +335,7 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.35rem 0.9rem;
-  border-radius: 999px;
+  border-radius: 0;
   background: rgba(248, 150, 30, 0.15);
   color: #f8961e;
   font-weight: 600;
@@ -355,7 +355,7 @@
   border-radius: 0.85rem;
   border: 1px solid transparent;
   padding: 0.75rem 0.9rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(18, 18, 30, 0.05);
   color: inherit;
   cursor: pointer;
   transition: border-color 140ms ease, transform 140ms ease, background 140ms ease;
@@ -397,7 +397,7 @@
   border: 1px solid var(--vault-border);
   border-radius: 0.8rem;
   padding: 0.8rem;
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(18, 18, 30, 0.03);
 }
 
 .set-summary p {

--- a/src/apps/sokoban-vault/styles.css
+++ b/src/apps/sokoban-vault/styles.css
@@ -1,13 +1,13 @@
 :root {
-  --vault-bg: #0b132b;
-  --vault-panel: #131e3a;
-  --vault-panel-alt: #18264b;
-  --vault-border: rgba(18, 18, 30, 0.06);
-  --vault-text: #f5f7ff;
-  --vault-muted: rgba(245, 247, 255, 0.7);
-  --crate: #fcd34d;
-  --crate-home: #4ade80;
-  --player: #f97316;
+  --vault-bg: #ececf2;
+  --vault-panel: #ffffff;
+  --vault-panel-alt: #f6f6f9;
+  --vault-border: rgba(18, 18, 30, 0.12);
+  --vault-text: #14141a;
+  --vault-muted: rgba(20, 20, 26, 0.58);
+  --crate: #eab308;
+  --crate-home: #22c55e;
+  --player: #ea580c;
 }
 
 .sokoban-layout {
@@ -21,9 +21,9 @@
 .selector-panel {
   background: var(--vault-panel);
   border: 1px solid var(--vault-border);
-  border-radius: 1rem;
+  border-radius: var(--radius, 6px);
   padding: 1.5rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-deep);
 }
 
 .selector-panel {
@@ -47,7 +47,7 @@
 
 .meta-chip {
   padding: 0.15rem 0.6rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.06);
   font-size: 0.85rem;
   color: var(--vault-muted);
@@ -83,7 +83,7 @@
   position: relative;
   margin-top: 1.5rem;
   padding: 1rem;
-  border-radius: 1rem;
+  border-radius: var(--radius, 6px);
   background: transparent;
   border: 1px solid var(--vault-border);
   overflow: hidden;
@@ -125,8 +125,8 @@
 }
 
 .tile[data-tile='wall'] {
-  background: linear-gradient(135deg, #1c2541, #0b132b);
-  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.06);
+  background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+  box-shadow: inset 0 0 0 1px rgba(18, 18, 30, 0.08);
 }
 
 .tile[data-tile='target'] {
@@ -140,12 +140,16 @@
   inset: 16%;
   border-radius: 0.3rem;
   background: var(--crate);
-  box-shadow: inset 0 -4px rgba(0, 0, 0, 0.2), inset 0 0 0 2px rgba(0, 0, 0, 0.15);
+  box-shadow:
+    inset 0 -2px rgba(18, 18, 30, 0.12),
+    inset 0 0 0 1px rgba(18, 18, 30, 0.14);
 }
 
 .tile[data-box='settled']::after {
   background: var(--crate-home);
-  box-shadow: inset 0 -4px rgba(0, 0, 0, 0.25);
+  box-shadow:
+    inset 0 -2px rgba(18, 18, 30, 0.14),
+    inset 0 0 0 1px rgba(18, 18, 30, 0.12);
 }
 
 .tile[data-player]::before {
@@ -154,7 +158,7 @@
   inset: 25%;
   border-radius: 50%;
   background: var(--player);
-  box-shadow: 0 4px 10px rgba(249, 115, 22, 0.6);
+  box-shadow: 0 2px 6px rgba(234, 88, 12, 0.35);
 }
 
 .tile[data-player='goal']::before {
@@ -164,8 +168,8 @@
 .solved-banner {
   position: absolute;
   inset: 0;
-  background: rgba(8, 14, 31, 0.82);
-  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius, 6px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -188,6 +192,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
+  color: var(--vault-text);
 }
 
 .control-row {
@@ -237,7 +242,7 @@
 
 .ghost-button,
 .primary-button {
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 0.5rem 1.3rem;
   border: 1px solid var(--vault-border);
   background: transparent;
@@ -319,9 +324,9 @@
 .selector-header input,
 .selector-header select {
   width: 100%;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--vault-border);
-  background: rgba(0, 0, 0, 0.2);
+  background: #ffffff;
   color: var(--vault-text);
   padding: 0.5rem 0.9rem;
 }
@@ -335,7 +340,7 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.35rem 0.9rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(248, 150, 30, 0.15);
   color: #f8961e;
   font-weight: 600;

--- a/src/apps/task-tracker/styles.css
+++ b/src/apps/task-tracker/styles.css
@@ -1,6 +1,6 @@
 :root {
   --tt-surface: rgba(15, 18, 35, 0.92);
-  --tt-border: rgba(255, 255, 255, 0.08);
+  --tt-border: rgba(18, 18, 30, 0.06);
   --tt-radius: 20px;
   --tt-radius-sm: 12px;
 }
@@ -36,7 +36,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .stat-value {
@@ -64,8 +64,8 @@
   padding: 10px 20px;
   border-radius: var(--tt-radius-sm);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.85);
+  background: rgba(18, 18, 30, 0.04);
+  color: var(--text);
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
@@ -73,8 +73,8 @@
 }
 
 .view-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(18, 18, 30, 0.06);
+  border-color: var(--text-muted);
 }
 
 .view-btn.active {
@@ -124,9 +124,9 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0;
+  background: rgba(18, 18, 30, 0.05);
+  border: 1px solid var(--border-soft);
   font-size: 0.85rem;
   font-weight: 500;
 }
@@ -134,7 +134,7 @@
 .chip-remove {
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
   cursor: pointer;
   padding: 0 2px;
   font-size: 1.1rem;
@@ -210,7 +210,7 @@
 }
 
 .primary-btn {
-  background: color-mix(in srgb, var(--accent) 75%, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--accent) 75%, var(--border-soft));
   color: #0f0f1a;
 }
 
@@ -220,13 +220,13 @@
 }
 
 .secondary-btn {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(18, 18, 30, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .secondary-btn:hover {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--border-soft);
 }
 
 .danger-btn {
@@ -261,7 +261,7 @@
 
 .kanban-view::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 999px;
+  border-radius: 0;
 }
 
 .kanban-user-column {
@@ -295,7 +295,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
   padding: 6px 0;
 }
 
@@ -304,8 +304,8 @@
   min-height: 80px;
   padding: 12px;
   border-radius: var(--tt-radius-sm);
-  border: 2px dashed rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.02);
+  border: 2px dashed var(--border-soft);
+  background: rgba(18, 18, 30, 0.03);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -346,7 +346,7 @@
 
 .ticket-id {
   font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
 }
 
@@ -361,12 +361,12 @@
   font-size: 0.95rem;
   font-weight: 600;
   line-height: 1.35;
-  color: rgba(255, 255, 255, 0.95);
+  color: var(--text);
 }
 
 .ticket-meta {
   font-size: 0.78rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
 }
 
 /* Backlog */
@@ -377,7 +377,7 @@
 .backlog-empty {
   padding: 32px;
   text-align: center;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
   font-size: 1rem;
 }
 
@@ -406,7 +406,7 @@
 
 .backlog-assign {
   padding: 8px 12px;
-  border-radius: 8px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(2, 4, 14, 0.6);
   color: #fff;
@@ -447,14 +447,14 @@
 .modal-ticket-title {
   margin: 0;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
   line-height: 1.4;
 }
 
 .modal-hint {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
 .modal-input {

--- a/src/apps/task-tracker/styles.css
+++ b/src/apps/task-tracker/styles.css
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-raised);
 }
 
 .stat-label {
@@ -124,7 +124,7 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: rgba(18, 18, 30, 0.05);
   border: 1px solid var(--border-soft);
   font-size: 0.85rem;
@@ -211,7 +211,7 @@
 
 .primary-btn {
   background: color-mix(in srgb, var(--accent) 75%, var(--border-soft));
-  color: #0f0f1a;
+  color: var(--text);
 }
 
 .primary-btn:hover {
@@ -261,7 +261,7 @@
 
 .kanban-view::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.2);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
 }
 
 .kanban-user-column {
@@ -327,11 +327,11 @@
   gap: 6px;
   cursor: grab;
   transition: box-shadow 140ms ease, transform 140ms ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-raised);
 }
 
 .ticket-card:hover {
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-raised);
 }
 
 .ticket-card.dragging {
@@ -406,7 +406,7 @@
 
 .backlog-assign {
   padding: 8px 12px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(2, 4, 14, 0.6);
   color: #fff;
@@ -418,7 +418,7 @@
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(22, 22, 30, 0.38);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -434,7 +434,7 @@
   padding: 28px;
   max-width: 400px;
   width: 100%;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-deep);
   display: grid;
   gap: 16px;
 }

--- a/src/apps/text-case-studio/styles.css
+++ b/src/apps/text-case-studio/styles.css
@@ -8,11 +8,11 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 28px);
-  border-radius: 26px;
-  background: rgba(11, 14, 27, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0;
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(18, 18, 30, 0.05),
     0 25px 45px rgba(6, 7, 13, 0.55);
   overflow: hidden;
 }
@@ -22,7 +22,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 10% -15%, color-mix(in srgb, var(--accent) 60%, transparent) 0%, transparent 60%);
+  background: transparent;
   opacity: 0.55;
 }
 
@@ -41,7 +41,7 @@
 
 .tcs-card-header p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -58,10 +58,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: 0;
   border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.92);
+  background: rgba(18, 18, 30, 0.05);
+  color: var(--text);
   padding: 10px 16px;
   font-weight: 600;
   font-size: 0.92rem;
@@ -71,7 +71,7 @@
 }
 
 .tcs-btn.primary {
-  background: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.06));
+  background: color-mix(in srgb, var(--accent) 40%, rgba(18, 18, 30, 0.05));
   border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.22));
 }
 
@@ -79,7 +79,7 @@
 .tcs-btn:focus-visible {
   outline: none;
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22));
-  background: color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--accent) 22%, rgba(18, 18, 30, 0.06));
   transform: translateY(-1px);
   box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
 }
@@ -99,18 +99,18 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--text-muted);
 }
 
 .tcs-textarea {
   position: relative;
   z-index: 1;
   min-height: clamp(220px, 30vh, 360px);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(3, 5, 15, 0.84);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 16px 18px;
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--text);
   font-size: clamp(0.95rem, 1.8vw, 1.05rem);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
   line-height: 1.6;
@@ -130,12 +130,12 @@
   flex-wrap: wrap;
   gap: 14px;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.62);
+  color: var(--text-muted);
 }
 
 .tcs-stat strong {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text);
 }
 
 .tcs-tool-grid {
@@ -149,11 +149,11 @@
 .tcs-status {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 0;
   background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--text);
   opacity: 0;
   transform: translateY(8px);
   transition: opacity 200ms ease, transform 200ms ease;

--- a/src/apps/text-case-studio/styles.css
+++ b/src/apps/text-case-studio/styles.css
@@ -8,7 +8,7 @@
   display: grid;
   gap: 18px;
   padding: clamp(20px, 3vw, 28px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #ffffff;
   border: 1px solid var(--border-soft);
   box-shadow:
@@ -58,7 +58,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(18, 18, 30, 0.05);
   color: var(--text);
@@ -81,7 +81,7 @@
   border-color: color-mix(in srgb, var(--accent) 70%, rgba(255, 255, 255, 0.22));
   background: color-mix(in srgb, var(--accent) 22%, rgba(18, 18, 30, 0.06));
   transform: translateY(-1px);
-  box-shadow: 0 12px 20px rgba(9, 12, 22, 0.4);
+  box-shadow: var(--shadow-deep);
 }
 
 .tcs-btn:disabled {
@@ -106,7 +106,7 @@
   position: relative;
   z-index: 1;
   min-height: clamp(220px, 30vh, 360px);
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 16px 18px;
@@ -149,8 +149,8 @@
 .tcs-status {
   justify-self: stretch;
   padding: 12px 16px;
-  border-radius: 0;
-  background: rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius, 6px);
+  background: rgba(18, 18, 30, 0.06);
   border: 1px solid rgba(18, 18, 30, 0.06);
   font-size: 0.95rem;
   color: var(--text);

--- a/src/apps/vibe-palette/styles.css
+++ b/src/apps/vibe-palette/styles.css
@@ -1,13 +1,10 @@
 .gradient-preview {
   position: relative;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   min-height: 260px;
   border: 1px solid var(--border-soft);
   overflow: hidden;
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.96) inset,
-    0 2px 6px rgba(16, 16, 28, 0.05),
-    0 12px 28px rgba(16, 16, 28, 0.07);
+  box-shadow: var(--shadow-deep);
 }
 
 .gradient-overlay {
@@ -21,13 +18,10 @@
   display: grid;
   gap: 24px;
   background: #ffffff;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   padding: clamp(20px, 3vw, 28px);
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.96) inset,
-    0 2px 6px rgba(16, 16, 28, 0.05),
-    0 10px 24px rgba(16, 16, 28, 0.06);
+  box-shadow: var(--shadow-deep);
 }
 
 .control {
@@ -77,14 +71,14 @@
   height: 44px;
   padding: 0;
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: transparent;
 }
 
 .stop-inputs input[type='text'] {
   font-family: 'Figtree', ui-sans-serif, sans-serif;
   font-size: 0.95rem;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   border: 1px solid var(--border-soft);
   background: #f6f6f9;
   padding: 10px 12px;
@@ -104,7 +98,7 @@
 
 .action-btn {
   border: none;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   padding: 12px 20px;
   font-weight: 600;
   font-size: 0.95rem;
@@ -116,7 +110,7 @@
 
 .action-btn.primary {
   background: color-mix(in srgb, var(--accent) 50%, rgba(18, 18, 30, 0.06));
-  box-shadow: 0 12px 24px -18px var(--accent);
+  box-shadow: var(--shadow-raised);
 }
 
 .action-btn:hover,
@@ -129,7 +123,7 @@
 .code-block {
   margin: 0;
   padding: 20px 24px;
-  border-radius: 0;
+  border-radius: var(--radius, 6px);
   background: #f6f6f9;
   border: 1px solid rgba(18, 18, 30, 0.05);
   font-family: 'Fira Code', 'Space Mono', 'SFMono-Regular', monospace;

--- a/src/apps/vibe-palette/styles.css
+++ b/src/apps/vibe-palette/styles.css
@@ -1,10 +1,13 @@
 .gradient-preview {
   position: relative;
-  border-radius: 28px;
+  border-radius: 0;
   min-height: 260px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-soft);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 35px 65px -55px rgba(0, 0, 0, 0.6);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 12px 28px rgba(16, 16, 28, 0.07);
 }
 
 .gradient-overlay {
@@ -17,10 +20,14 @@
 .gradient-controls {
   display: grid;
   gap: 24px;
-  background: rgba(18, 19, 36, 0.8);
-  border-radius: 26px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: #ffffff;
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
   padding: clamp(20px, 3vw, 28px);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 10px 24px rgba(16, 16, 28, 0.06);
 }
 
 .control {
@@ -33,7 +40,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
 }
 
 .range-row {
@@ -51,7 +58,7 @@
   min-width: 44px;
   text-align: right;
   font-variant-numeric: tabular-nums;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
 }
 
 .stops-list {
@@ -70,16 +77,16 @@
   height: 44px;
   padding: 0;
   border: none;
-  border-radius: 14px;
+  border-radius: 0;
   background: transparent;
 }
 
 .stop-inputs input[type='text'] {
-  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-family: 'Figtree', ui-sans-serif, sans-serif;
   font-size: 0.95rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(0, 0, 0, 0.2);
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: #f6f6f9;
   padding: 10px 12px;
   color: inherit;
 }
@@ -97,18 +104,18 @@
 
 .action-btn {
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   padding: 12px 20px;
   font-weight: 600;
   font-size: 0.95rem;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border-soft);
   color: inherit;
   cursor: pointer;
   transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease;
 }
 
 .action-btn.primary {
-  background: color-mix(in srgb, var(--accent) 50%, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--accent) 50%, rgba(18, 18, 30, 0.06));
   box-shadow: 0 12px 24px -18px var(--accent);
 }
 
@@ -122,12 +129,12 @@
 .code-block {
   margin: 0;
   padding: 20px 24px;
-  border-radius: 20px;
-  background: rgba(10, 12, 26, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 0;
+  background: #f6f6f9;
+  border: 1px solid rgba(18, 18, 30, 0.05);
   font-family: 'Fira Code', 'Space Mono', 'SFMono-Regular', monospace;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.86);
+  color: var(--text);
   overflow-x: auto;
 }
 
@@ -136,7 +143,7 @@
   transform: translateY(8px);
   transition: opacity 200ms ease, transform 200ms ease;
   font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text);
 }
 
 .toast.visible {

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1,228 +1,226 @@
 export const apps = [
-    {
-      slug: 'apriltag-scout',
-      title: 'AprilTag Scout',
-      blurb: 'Stream a live camera view as AprilTags are outlined with IDs, family metadata, pose hints, and orientation arrows.',
-      icon: '🎯',
-      href: 'apps/apriltag-scout/index.html',
-      accent: '#ff914d'
-    },
-    {
-      slug: 'create-dot-to-dot-designer',
-      title: 'Dot-to-Dot Designer',
-      blurb: 'Drop numbered dots on a blank canvas, preview links mid-drag, and undo or clear to polish your connect-the-dots artwork.',
-      icon: '🔢',
-      href: 'apps/create-dot-to-dot-designer/index.html',
-      accent: '#7ad7ff'
-    },
-    {
-      slug: 'morse-code-studio',
-      title: 'Morse Code Studio',
-      blurb: 'Tap, speak, or type Morse to decode live, then generate matching dots, dashes, and tone playback.',
-      icon: '📡',
-      href: 'apps/morse-code-studio/index.html',
-      accent: '#ffd166'
-    },
-    {
-      slug: 'camera-filter-lab',
-      title: 'FilterCam Playground',
-      blurb: 'Open your webcam, then bounce between cinematic, diagnostic, and just-for-fun filter presets complete with live descriptions.',
-      icon: '📷',
-      href: 'apps/camera-filter-lab/index.html',
-      accent: '#ff5f6d'
-    },
-    {
-      slug: 'scan-vector-lab',
-      title: 'Dimension Scan Lab',
-      blurb: 'Print a calibrated board, lock onto the tags, and export mm-accurate SVG, DXF, or PDF outlines of objects on the page.',
-      icon: '📐',
-      href: 'apps/scan-vector-lab/index.html',
-      accent: '#1f7a8c'
-    },
-    {
-      slug: 'screen-shape-measurement-tool',
-      title: 'Screen Shape Measurement Tool',
-      blurb: 'Estimate screen scale, calibrate a reference line, and preview real-world shapes on screen.',
-      icon: '📏',
-      href: 'apps/screen-shape-measurement-tool/index.html',
-      accent: '#5cf7c1'
-    },
-    {
-      slug: 'clean-url-tracker-remover',
-      title: 'Clean URL Trimmer',
-      blurb: 'Paste a sharing link and drop all the ad trackers, redirect junk, and campaign tags in one click.',
-      icon: '🧼',
-      href: 'apps/clean-url-tracker-remover/index.html',
-      accent: '#48cae4'
-    },
-    {
-      slug: 'quick-diff',
-      title: 'Quick Diff',
-      blurb: 'Line up two snippets and spot the precise character changes with inline highlights for insertions and deletions.',
-      icon: '📝',
-      href: 'apps/quick-diff/index.html',
-      accent: '#3a86ff'
-    },
-    {
-      slug: 'quick-list-tools',
-      title: 'Quick List Tools',
-      blurb: 'Paste a list and instantly sort it, de-dupe values, run a frequency count, quote items, and convert delimiters.',
-      icon: '📋',
-      href: 'apps/quick-list-tools/index.html',
-      accent: '#7ee8fa'
-    },
-    {
-      slug: 'reverse-engineering-lab',
-      title: 'Protocol Decoder Lab',
-      blurb: 'Paste unknown data blobs to detect encodings, decode bytes, and identify common protocols automatically.',
-      icon: '🕵️',
-      href: 'apps/reverse-engineering-lab/index.html',
-      accent: '#9d4edd'
-    },
-    {
-      slug: 'roman-numeral-translator',
-      title: 'Roman Numeral Translator',
-      blurb: 'Convert roman numerals to numbers (and back) with instant validation and history.',
-      icon: '🏛️',
-      href: 'apps/roman-numeral-translator/index.html',
-      accent: '#f08c4a'
-    },
-    {
-      slug: 'slope-intercept-calculator',
-      title: 'Slope-Intercept Calculator',
-      blurb: 'Enter two points to solve the slope (m) and intercept (c) in y = mx + c.',
-      icon: '📈',
-      href: 'apps/slope-intercept-calculator/index.html',
-      accent: '#4cc9f0'
-    },
-    {
-      slug: 'vibe-palette',
-      title: 'Aura Gradient Mixer',
-      blurb: 'Blend colors into dreamy gradients and copy CSS-ready code in a snap.',
-      icon: '🌈',
-      href: 'apps/vibe-palette/index.html',
-      accent: '#ff7ee7'
-    },
-    {
-      slug: 'clipboard-alchemist',
-      title: 'Clipboard Alchemist',
-      blurb: 'Transform whatever is on your clipboard—format JSON, minify, encode, or replace text.',
-      icon: '🧪',
-      href: 'apps/clipboard-alchemist/index.html',
-      accent: '#5ae4a7'
-    },
-    {
-      slug: 'text-case-studio',
-      title: 'Text Case Studio',
-      blurb: 'Paste text from your clipboard and instantly convert it to title case, sentence case, lower case, and more.',
-      icon: '🔤',
-      href: 'apps/text-case-studio/index.html',
-      accent: '#2dd4bf'
-    },
-    {
-      slug: 'palette-maker',
-      title: 'Palette Maker',
-      blurb: 'Build harmonious palettes with theory-backed suggestions and accessibility checks.',
-      icon: '🎨',
-      href: 'apps/palette-maker/index.html',
-      accent: '#f6b44e'
-    },
-    {
-      slug: 'qr-code-generator',
-      title: 'Local QR Studio',
-      blurb: 'Type or paste text, preview four redundancy levels, and download pristine PNG or SVG QR codes instantly.',
-      icon: '🔳',
-      href: 'apps/qr-code-generator/index.html',
-      accent: '#64d7ff'
-    },
-    {
-      slug: 'random-name-selector',
-      title: 'Random Name Selector',
-      blurb: 'Paste a list of names, shuffle once, and reveal each name exactly once with a Next button.',
-      icon: '🎲',
-      href: 'apps/random-name-selector/index.html',
-      accent: '#7ee8fa'
-    },
-    {
-      slug: 'browser-diagnostic',
-      title: 'Browser Systems Diagnostic',
-      blurb: 'Run a slow, deliberate sweep of browser features, permissions, and experimental APIs from a glowing command console.',
-      icon: '🧰',
-      href: 'apps/browser-diagnostic/index.html',
-      accent: '#b7410e'
-    },
-    {
-      slug: 'nesting-algorithm-visualizer',
-      title: 'Nesting Algorithm Lab',
-      blurb: 'Watch convex polygons pack themselves into a sheet using fast heuristics, then tweak parameters and rerun instantly.',
-      icon: '🧩',
-      href: 'apps/nesting-algorithm-visualizer/index.html',
-      accent: '#ff6f61'
-    },
-    {
-      slug: 'sokoban-vault',
-      title: 'Sokoban Vault',
-      blurb: 'Play hundreds of curated Sokoban puzzles with a progress-aware level browser and instant switching.',
-      icon: '🧱',
-      href: 'apps/sokoban-vault/index.html',
-      accent: '#f8961e'
-    },
-    {
-      slug: 'score-taking-app',
-      title: 'Scorecard Studio',
-      blurb: 'Build ad-hoc score grids: add columns for players, log rounds, and keep running totals pinned to the top row.',
-      icon: '📊',
-      href: 'apps/score-taking-app/index.html',
-      accent: '#ff7b54'
-    },
-    {
-      slug: 'task-tracker',
-      title: 'Task Tracker',
-      blurb: 'A lightweight Jira-style board. Kanban grouped by user, backlog, sprint states, and points tracking—all saved locally.',
-      icon: '📋',
-      href: 'apps/task-tracker/index.html',
-      accent: '#4f46e5'
-    },
-    {
-      slug: 'pdf-forensic-analysis',
-      title: 'PDF Forensic Analysis',
-      blurb: 'Upload a PDF and inspect low-level forensic details: version, features, embedded images, compression, fonts, and more. Runs entirely in your browser.',
-      icon: '🔍',
-      href: 'apps/pdf-forensic-analysis/index.html',
-      accent: '#e07a5f'
-    },
-    {
-      slug: 'markdown-repair',
-      title: 'Markdown Repair',
-      blurb: 'Repair and reformat markdown: fix line breaks, soft hyphens, broken bullets, tables, trailing spaces, and extra line breaks.',
-      icon: '📝',
-      href: 'apps/markdown-repair/index.html',
-      accent: '#6ee7b7'
-    },
-    {
-      slug: 'piano-and-stave',
-      title: 'Piano Stave Studio',
-      blurb: 'Click a piano, hear each tone, and watch matching notes land on a live treble staff.',
-      icon: '🎹',
-      href: 'apps/piano-and-stave/index.html',
-      accent: '#6f6bff'
-    },
-    {
-      slug: 'audio-spectrum-analyser',
-      title: 'Audio Spectrum Analyser',
-      blurb:
-        'Microphone FFT on a log-frequency axis: live curve with max and average, a heatmap history that scrolls downward, and a tunable single-frequency readout in dB or friendlier units.',
-      icon: '📊',
-      href: 'apps/audio-spectrum-analyser/index.html',
-      accent: '#00d4aa'
-    },
-    {
-      slug: 'polyrhythm-drum-sequencer',
-      title: 'Polyrhythm Drum Sequencer',
-      blurb:
-        'Layer loops that share one bar but divide it into different beat counts—kick, snare, hats, cowbell, FM, and laser zap per track, with beats-per-bar you control.',
-      icon: '🥁',
-      href: 'apps/polyrhythm-drum-sequencer/index.html',
-      accent: '#e8a838'
-    }
+  {
+    slug: 'apriltag-scout',
+    title: 'AprilTag Scout',
+    blurb: 'Live camera with tag outlines, IDs, and pose hints.',
+    icon: '🎯',
+    href: 'apps/apriltag-scout/index.html',
+    accent: '#ff914d'
+  },
+  {
+    slug: 'create-dot-to-dot-designer',
+    title: 'Dot-to-Dot Designer',
+    blurb: 'Place numbered dots; preview lines while you drag.',
+    icon: '🔢',
+    href: 'apps/create-dot-to-dot-designer/index.html',
+    accent: '#7ad7ff'
+  },
+  {
+    slug: 'morse-code-studio',
+    title: 'Morse Code Studio',
+    blurb: 'Tap, speak, or type Morse; decode live with playback.',
+    icon: '📡',
+    href: 'apps/morse-code-studio/index.html',
+    accent: '#ffd166'
+  },
+  {
+    slug: 'camera-filter-lab',
+    title: 'FilterCam Playground',
+    blurb: 'Webcam filters with presets and short live captions.',
+    icon: '📷',
+    href: 'apps/camera-filter-lab/index.html',
+    accent: '#ff5f6d'
+  },
+  {
+    slug: 'scan-vector-lab',
+    title: 'Dimension Scan Lab',
+    blurb: 'Print a board, lock tags, export mm-accurate outlines.',
+    icon: '📐',
+    href: 'apps/scan-vector-lab/index.html',
+    accent: '#1f7a8c'
+  },
+  {
+    slug: 'screen-shape-measurement-tool',
+    title: 'Screen Shape Measurement Tool',
+    blurb: 'Calibrate scale and preview real shapes on screen.',
+    icon: '📏',
+    href: 'apps/screen-shape-measurement-tool/index.html',
+    accent: '#5cf7c1'
+  },
+  {
+    slug: 'clean-url-tracker-remover',
+    title: 'Clean URL Trimmer',
+    blurb: 'Paste a link; strip trackers and junk query params.',
+    icon: '🧼',
+    href: 'apps/clean-url-tracker-remover/index.html',
+    accent: '#48cae4'
+  },
+  {
+    slug: 'quick-diff',
+    title: 'Quick Diff',
+    blurb: 'Compare two snippets with character-level highlights.',
+    icon: '📝',
+    href: 'apps/quick-diff/index.html',
+    accent: '#3a86ff'
+  },
+  {
+    slug: 'quick-list-tools',
+    title: 'Quick List Tools',
+    blurb: 'Sort, dedupe, count, quote, and reshape pasted lists.',
+    icon: '📋',
+    href: 'apps/quick-list-tools/index.html',
+    accent: '#7ee8fa'
+  },
+  {
+    slug: 'reverse-engineering-lab',
+    title: 'Protocol Decoder Lab',
+    blurb: 'Decode mystery blobs: encodings, bytes, common protocols.',
+    icon: '🕵️',
+    href: 'apps/reverse-engineering-lab/index.html',
+    accent: '#9d4edd'
+  },
+  {
+    slug: 'roman-numeral-translator',
+    title: 'Roman Numeral Translator',
+    blurb: 'Roman ↔ Arabic numerals with checks and history.',
+    icon: '🏛️',
+    href: 'apps/roman-numeral-translator/index.html',
+    accent: '#f08c4a'
+  },
+  {
+    slug: 'slope-intercept-calculator',
+    title: 'Slope-Intercept Calculator',
+    blurb: 'Two points → slope m and intercept c for y = mx + c.',
+    icon: '📈',
+    href: 'apps/slope-intercept-calculator/index.html',
+    accent: '#4cc9f0'
+  },
+  {
+    slug: 'vibe-palette',
+    title: 'Aura Gradient Mixer',
+    blurb: 'Blend gradients and copy ready-to-paste CSS.',
+    icon: '🌈',
+    href: 'apps/vibe-palette/index.html',
+    accent: '#ff7ee7'
+  },
+  {
+    slug: 'clipboard-alchemist',
+    title: 'Clipboard Alchemist',
+    blurb: 'Format JSON, minify, encode, or rewrite clipboard text.',
+    icon: '🧪',
+    href: 'apps/clipboard-alchemist/index.html',
+    accent: '#5ae4a7'
+  },
+  {
+    slug: 'text-case-studio',
+    title: 'Text Case Studio',
+    blurb: 'Clipboard in; title, sentence, lower, and other cases out.',
+    icon: '🔤',
+    href: 'apps/text-case-studio/index.html',
+    accent: '#2dd4bf'
+  },
+  {
+    slug: 'palette-maker',
+    title: 'Palette Maker',
+    blurb: 'Build palettes with theory tips and contrast checks.',
+    icon: '🎨',
+    href: 'apps/palette-maker/index.html',
+    accent: '#f6b44e'
+  },
+  {
+    slug: 'qr-code-generator',
+    title: 'Local QR Studio',
+    blurb: 'Text to QR; PNG or SVG and pick redundancy level.',
+    icon: '🔳',
+    href: 'apps/qr-code-generator/index.html',
+    accent: '#64d7ff'
+  },
+  {
+    slug: 'random-name-selector',
+    title: 'Random Name Selector',
+    blurb: 'Shuffle a name list and reveal entries one at a time.',
+    icon: '🎲',
+    href: 'apps/random-name-selector/index.html',
+    accent: '#7ee8fa'
+  },
+  {
+    slug: 'browser-diagnostic',
+    title: 'Browser Systems Diagnostic',
+    blurb: 'Probe features, permissions, and APIs from one console.',
+    icon: '🧰',
+    href: 'apps/browser-diagnostic/index.html',
+    accent: '#b7410e'
+  },
+  {
+    slug: 'nesting-algorithm-visualizer',
+    title: 'Nesting Algorithm Lab',
+    blurb: 'Pack polygons on a sheet; change settings and rerun.',
+    icon: '🧩',
+    href: 'apps/nesting-algorithm-visualizer/index.html',
+    accent: '#ff6f61'
+  },
+  {
+    slug: 'sokoban-vault',
+    title: 'Sokoban Vault',
+    blurb: 'Hundreds of Sokoban levels with progress and quick jumps.',
+    icon: '🧱',
+    href: 'apps/sokoban-vault/index.html',
+    accent: '#f8961e'
+  },
+  {
+    slug: 'score-taking-app',
+    title: 'Scorecard Studio',
+    blurb: 'Score grids: players, rounds, and running totals.',
+    icon: '📊',
+    href: 'apps/score-taking-app/index.html',
+    accent: '#ff7b54'
+  },
+  {
+    slug: 'task-tracker',
+    title: 'Task Tracker',
+    blurb: 'Local Kanban: columns, backlog, sprints, story points.',
+    icon: '📋',
+    href: 'apps/task-tracker/index.html',
+    accent: '#4f46e5'
+  },
+  {
+    slug: 'pdf-forensic-analysis',
+    title: 'PDF Forensic Analysis',
+    blurb: 'Inspect PDF internals—fonts, streams, images—all offline.',
+    icon: '🔍',
+    href: 'apps/pdf-forensic-analysis/index.html',
+    accent: '#e07a5f'
+  },
+  {
+    slug: 'markdown-repair',
+    title: 'Markdown Repair',
+    blurb: 'Tidy broken markdown: lists, tables, breaks, spacing.',
+    icon: '📝',
+    href: 'apps/markdown-repair/index.html',
+    accent: '#6ee7b7'
+  },
+  {
+    slug: 'piano-and-stave',
+    title: 'Piano Stave Studio',
+    blurb: 'Play keys; hear tones and see notes on a treble staff.',
+    icon: '🎹',
+    href: 'apps/piano-and-stave/index.html',
+    accent: '#6f6bff'
+  },
+  {
+    slug: 'audio-spectrum-analyser',
+    title: 'Audio Spectrum Analyser',
+    blurb: 'Mic spectrum, scrolling heatmap, and tunable level readout.',
+    icon: '📊',
+    href: 'apps/audio-spectrum-analyser/index.html',
+    accent: '#00d4aa'
+  },
+  {
+    slug: 'polyrhythm-drum-sequencer',
+    title: 'Polyrhythm Drum Sequencer',
+    blurb: 'Layer loops with different beat splits in one shared bar.',
+    icon: '🥁',
+    href: 'apps/polyrhythm-drum-sequencer/index.html',
+    accent: '#e8a838'
+  }
 ];

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,6 @@ function createAppCard(app) {
     <span class="app-icon" aria-hidden="true">${app.icon}</span>
     <span class="app-title">${app.title}</span>
     <span class="app-blurb">${app.blurb}</span>
-    <span class="app-link" aria-hidden="true"></span>
   `;
   return card;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,12 @@ function createAppCard(app) {
   card.href = app.href;
   card.dataset.slug = app.slug;
   card.setAttribute('style', `--accent:${app.accent};`);
+  card.setAttribute('aria-label', `${app.title}. ${app.blurb}`);
   card.innerHTML = `
     <span class="app-icon" aria-hidden="true">${app.icon}</span>
     <span class="app-title">${app.title}</span>
     <span class="app-blurb">${app.blurb}</span>
-    <span class="app-link">Launch ↗</span>
+    <span class="app-link" aria-hidden="true"></span>
   `;
   return card;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ function createHero() {
   hero.innerHTML = `
     <span class="hero-eyebrow">Matt Presents</span>
     <h1>Vibe-Coded App Hub</h1>
-    <p>Micro web experiments with big feelings. Click any card to open a focused tool in a new page.</p>
+    <p>Small, focused web tools I ship as static pages—open a card to try one; each runs entirely in your browser.</p>
   `;
   return hero;
 }
@@ -46,51 +46,41 @@ function createAbout() {
     <div class="about-card">
       <h2>What is this place?</h2>
       <p>
-        This hub is a living collection of pocket-sized webapps built by Matt and delivered via GitHub Pages.
-        Each tool runs entirely in your browser—no accounts, no tracking, just playful utility.
+        This is my living gallery of pocket-sized web apps on GitHub Pages—no accounts, no tracking, just the tool in front of you.
       </p>
       <p>
-        Built with AI assistance and deployed automatically. When ideas are submitted, AI agents write the code, and updates go live within minutes.
+        I use AI-assisted workflows to turn ideas into code quickly; everything here is open and deployed automatically.
       </p>
-      <p class="about-meta">New experiments launch regularly—check back often or submit your own idea!</p>
+      <p class="about-meta">New experiments appear often—drop by again or suggest something you’d like built.</p>
+
+      <h3 class="about-subheading">From idea to live app</h3>
+      <ol class="timeline-steps">
+        <li>
+          <span class="timeline-duration">Step 1</span>
+          <span class="timeline-description">
+            You send an idea through <a href="https://cursor.com/agents" target="_blank" rel="noopener noreferrer">Cursor Agents</a>
+            or a <a href="https://github.com/mattboys/agent-hub/issues" target="_blank" rel="noopener noreferrer">GitHub issue</a>.
+          </span>
+        </li>
+        <li>
+          <span class="timeline-duration">Step 2</span>
+          <span class="timeline-description">
+            Cloud agents run the work and open a pull request. GitHub Actions builds a preview of the site and shares a link so you can verify the change; when it looks right, I merge into <strong>main</strong>.
+          </span>
+        </li>
+        <li>
+          <span class="timeline-duration">Step 3</span>
+          <span class="timeline-description">
+            The production site updates on <a href="https://mattboys.github.io/agent-hub/" target="_blank" rel="noopener noreferrer">GitHub Pages</a>—usually within minutes of merge.
+          </span>
+        </li>
+      </ol>
+      <p class="timeline-total">
+        <span class="timeline-total-label">Typical turnaround:</span>
+        minutes from idea to preview; merge when ready.
+      </p>
     </div>
   `;
-  return section;
-}
-
-function createTimeline() {
-  const section = document.createElement('section');
-  section.className = 'timeline';
-  section.innerHTML = `
-      <div class="timeline-card">
-        <h2>From Idea to Live App</h2>
-        <ol class="timeline-steps">
-          <li>
-            <span class="timeline-duration">30s</span>
-            <span class="timeline-description">
-              User submits an idea via <a href="https://cursor.com/agents" target="_blank" rel="noopener noreferrer">Cursor Agents</a>
-              or <a href="https://github.com/mattboys/agent-hub/issues" target="_blank" rel="noopener noreferrer">GitHub Issues</a>.
-            </span>
-          </li>
-          <li>
-            <span class="timeline-duration">60s</span>
-            <span class="timeline-description">AI agents implement the request and open a pull request with the code changes.</span>
-          </li>
-          <li>
-            <span class="timeline-duration">5s</span>
-            <span class="timeline-description">The site admin reviews and approves the update.</span>
-          </li>
-          <li>
-            <span class="timeline-duration">40s</span>
-            <span class="timeline-description">GitHub Actions spins up a fresh VM to rebuild the site.</span>
-          </li>
-        </ol>
-        <p class="timeline-total">
-          <span class="timeline-total-label">Total:</span>
-          2min 15s — changes go live on <a href="https://mattboys.github.io/agent-hub/" target="_blank" rel="noopener noreferrer">GitHub Pages</a>.
-        </p>
-      </div>
-    `;
   return section;
 }
 
@@ -104,7 +94,6 @@ function init() {
 
   page.appendChild(createHero());
   page.appendChild(createAppGrid());
-  page.appendChild(createTimeline());
   page.appendChild(createAbout());
 
   root.innerHTML = '';

--- a/src/styles/app-base.css
+++ b/src/styles/app-base.css
@@ -13,14 +13,16 @@
   --field-bg: #f6f6f9;
   --border-soft: rgba(18, 18, 30, 0.12);
   --border-strong: rgba(18, 18, 30, 0.2);
+  --radius: 6px;
+  /* Short, subtle stacked depth — low blur/spread */
   --shadow-raised:
-    0 1px 0 rgba(255, 255, 255, 0.96) inset,
-    0 1px 3px rgba(16, 16, 28, 0.06),
-    0 6px 16px rgba(16, 16, 28, 0.06);
+    0 1px 0 rgba(255, 255, 255, 0.94) inset,
+    0 1px 2px rgba(16, 16, 28, 0.04),
+    0 2px 6px rgba(16, 16, 28, 0.045);
   --shadow-deep:
-    0 1px 0 rgba(255, 255, 255, 0.98) inset,
-    0 2px 6px rgba(16, 16, 28, 0.05),
-    0 14px 32px rgba(16, 16, 28, 0.08);
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 1px 2px rgba(16, 16, 28, 0.035),
+    0 3px 8px rgba(16, 16, 28, 0.05);
   font-family: 'Figtree', ui-sans-serif, system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.45;
@@ -69,7 +71,7 @@ a {
   width: 34px;
   height: 34px;
   padding: 0;
-  border-radius: 0;
+  border-radius: var(--radius);
   font-size: 0;
   background: var(--surface);
   border: 1px solid var(--border-soft);
@@ -89,8 +91,7 @@ a {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
   box-shadow:
     var(--shadow-raised),
-    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 35%, transparent),
-    0 0 18px color-mix(in srgb, var(--neon-cyan) 22%, transparent);
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 28%, transparent);
 }
 
 .back-link:focus-visible {
@@ -115,7 +116,7 @@ a {
 
 .app-body {
   background: var(--surface);
-  border-radius: 0;
+  border-radius: var(--radius);
   border: 1px solid var(--border-soft);
   padding: 10px 10px 12px;
   display: grid;
@@ -126,7 +127,7 @@ a {
 .app-body :where(input:not([type='checkbox']):not([type='radio']), textarea, select, button) {
   font: inherit;
   font-size: 0.8125rem;
-  border-radius: 0;
+  border-radius: var(--radius);
   border: 1px solid var(--border-soft);
   background: var(--field-bg);
   color: var(--text);
@@ -136,7 +137,7 @@ a {
   cursor: pointer;
   font-weight: 600;
   padding: 0.35rem 0.55rem;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.85) inset;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.88) inset;
 }
 
 .app-body :where(button:hover, input[type='submit']:hover, input[type='button']:hover) {
@@ -152,7 +153,7 @@ a {
   align-self: start;
   justify-self: start;
   padding: 3px 8px;
-  border-radius: 0;
+  border-radius: var(--radius);
   font-size: 0.65rem;
   font-weight: 700;
   letter-spacing: 0.06em;

--- a/src/styles/app-base.css
+++ b/src/styles/app-base.css
@@ -1,17 +1,29 @@
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap');
 
 :root {
-  color-scheme: dark light;
-  --accent: #8c8cff;
-  --surface: rgba(17, 19, 37, 0.72);
-  --surface-strong: rgba(24, 25, 45, 0.92);
-  --border-soft: rgba(255, 255, 255, 0.08);
-  --text: #f7f5ff;
-  --text-muted: rgba(247, 245, 255, 0.7);
-  --bg: radial-gradient(circle at 10% -10%, rgba(255, 225, 247, 0.4), transparent 40%),
-    radial-gradient(circle at 120% 30%, rgba(104, 235, 255, 0.3), transparent 45%),
-    #0c0d1d;
-  font-family: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: light;
+  --accent: #7b7bff;
+  --neon-magenta: #ff1dce;
+  --neon-cyan: #00e8c8;
+  --neon-lime: #d4ff00;
+  --bg: #ececf2;
+  --text: #14141a;
+  --text-muted: rgba(20, 20, 26, 0.58);
+  --surface: #ffffff;
+  --field-bg: #f6f6f9;
+  --border-soft: rgba(18, 18, 30, 0.12);
+  --border-strong: rgba(18, 18, 30, 0.2);
+  --shadow-raised:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 1px 3px rgba(16, 16, 28, 0.06),
+    0 6px 16px rgba(16, 16, 28, 0.06);
+  --shadow-deep:
+    0 1px 0 rgba(255, 255, 255, 0.98) inset,
+    0 2px 6px rgba(16, 16, 28, 0.05),
+    0 14px 32px rgba(16, 16, 28, 0.08);
+  font-family: 'Figtree', ui-sans-serif, system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
 }
 
 * {
@@ -25,12 +37,12 @@ body {
   color: var(--text);
   display: flex;
   justify-content: center;
-  padding: 56px 20px 80px;
+  padding: 10px 8px 28px;
 }
 
 @media (max-width: 720px) {
   body {
-    padding: 32px 14px 64px;
+    padding: 8px 6px 22px;
   }
 }
 
@@ -39,69 +51,128 @@ a {
 }
 
 .app-shell {
-  width: min(960px, 100%);
+  width: min(1080px, 100%);
   display: grid;
-  gap: 28px;
+  gap: 10px;
 }
 
 .app-header {
   display: grid;
-  gap: 12px;
+  gap: 4px;
 }
 
 .back-link {
   justify-self: start;
-  padding: 6px 14px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0;
+  background: var(--surface);
+  border: 1px solid var(--border-soft);
+  box-shadow: var(--shadow-raised);
   text-decoration: none;
-  transition: transform 160ms ease, background 160ms ease;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.back-link svg {
+  width: 18px;
+  height: 18px;
+  stroke: var(--text);
 }
 
 .back-link:hover,
 .back-link:focus-visible {
-  transform: translateY(-2px);
-  background: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-soft));
+  box-shadow:
+    var(--shadow-raised),
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 35%, transparent),
+    0 0 18px color-mix(in srgb, var(--neon-cyan) 22%, transparent);
+}
+
+.back-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--neon-magenta) 70%, var(--text));
+  outline-offset: 2px;
 }
 
 .app-header h1 {
   margin: 0;
-  font-size: clamp(2.1rem, 4vw, 3rem);
-  letter-spacing: -0.02em;
+  font-size: clamp(1.15rem, 2.4vw, 1.55rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
 }
 
 .app-header p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  max-width: 52ch;
 }
 
 .app-body {
   background: var(--surface);
-  border-radius: 28px;
+  border-radius: 0;
   border: 1px solid var(--border-soft);
-  padding: clamp(24px, 4vw, 36px);
+  padding: 10px 10px 12px;
   display: grid;
-  gap: 20px;
-  backdrop-filter: blur(18px);
+  gap: 10px;
+  box-shadow: var(--shadow-deep);
+}
+
+.app-body :where(input:not([type='checkbox']):not([type='radio']), textarea, select, button) {
+  font: inherit;
+  font-size: 0.8125rem;
+  border-radius: 0;
+  border: 1px solid var(--border-soft);
+  background: var(--field-bg);
+  color: var(--text);
+}
+
+.app-body :where(button, input[type='submit'], input[type='button']) {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.35rem 0.55rem;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.85) inset;
+}
+
+.app-body :where(button:hover, input[type='submit']:hover, input[type='button']:hover) {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border-soft));
+}
+
+.app-body :where(button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible) {
+  outline: 2px solid color-mix(in srgb, var(--neon-cyan) 65%, var(--text));
+  outline-offset: 1px;
 }
 
 .status-pill {
   align-self: start;
   justify-self: start;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 3px 8px;
+  border-radius: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  background: var(--field-bg);
+  border: 1px solid var(--border-soft);
+  border-left: 3px solid var(--neon-lime);
   text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10,14 +10,15 @@
   --neon-magenta: #ff1dce;
   --neon-cyan: #00e8c8;
   --neon-lime: #d4ff00;
+  --radius: 6px;
   --shadow-card:
-    0 1px 0 rgba(255, 255, 255, 0.96) inset,
-    0 1px 3px rgba(16, 16, 28, 0.05),
-    0 8px 20px rgba(16, 16, 28, 0.06);
+    0 1px 0 rgba(255, 255, 255, 0.94) inset,
+    0 1px 2px rgba(16, 16, 28, 0.04),
+    0 2px 6px rgba(16, 16, 28, 0.045);
   --shadow-card-hover:
-    0 1px 0 rgba(255, 255, 255, 0.98) inset,
-    0 2px 6px rgba(16, 16, 28, 0.06),
-    0 12px 28px rgba(16, 16, 28, 0.09);
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 1px 2px rgba(16, 16, 28, 0.05),
+    0 3px 9px rgba(16, 16, 28, 0.055);
   font-family: 'Figtree', ui-sans-serif, system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.45;
@@ -111,7 +112,7 @@ body {
   gap: 8px;
   padding: 12px 10px 12px;
   min-height: 0;
-  border-radius: 0;
+  border-radius: var(--radius);
   background: color-mix(in srgb, var(--accent) 30%, #ffffff);
   border: 1px solid color-mix(in srgb, var(--accent) 48%, rgba(18, 18, 30, 0.12));
   text-decoration: none;
@@ -130,7 +131,7 @@ body {
   border-color: color-mix(in srgb, var(--accent) 58%, rgba(18, 18, 30, 0.14));
   box-shadow:
     var(--shadow-card-hover),
-    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 28%, transparent);
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 22%, transparent);
 }
 
 .app-card:focus-visible {
@@ -146,7 +147,7 @@ body {
   height: clamp(44px, 14vw, 56px);
   align-items: center;
   justify-content: center;
-  border-radius: 0;
+  border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.42);
   border: 1px solid rgba(255, 255, 255, 0.55);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.75) inset;
@@ -178,7 +179,7 @@ body {
   width: 100%;
   max-width: none;
   padding: 12px 14px 14px;
-  border-radius: 0;
+  border-radius: var(--radius);
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   box-shadow: var(--shadow-card);
@@ -235,7 +236,7 @@ body {
   background: #f6f6f9;
   border: 1px solid var(--card-border);
   border-left: 3px solid var(--neon-cyan);
-  border-radius: 0;
+  border-radius: var(--radius);
   padding: 6px 8px;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,17 +1,26 @@
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&family=Space+Grotesk:wght@600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap');
 
 :root {
-  color-scheme: dark light;
-  --bg-gradient: radial-gradient(circle at 10% 20%, rgba(255, 190, 232, 0.4), transparent 35%),
-    radial-gradient(circle at 80% 0%, rgba(116, 235, 213, 0.35), transparent 40%),
-    #0f1020;
-  --text-primary: #f9f5ff;
-  --text-subtle: rgba(249, 245, 255, 0.72);
-  --card-bg: rgba(15, 16, 32, 0.66);
-  --card-border: rgba(255, 255, 255, 0.08);
-  --blur: blur(24px);
-  --transition: 220ms ease;
-  font-family: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: light;
+  --page-bg: #ececf2;
+  --text-primary: #14141a;
+  --text-subtle: rgba(20, 20, 26, 0.56);
+  --card-bg: #ffffff;
+  --card-border: rgba(18, 18, 30, 0.12);
+  --neon-magenta: #ff1dce;
+  --neon-cyan: #00e8c8;
+  --neon-lime: #d4ff00;
+  --shadow-card:
+    0 1px 0 rgba(255, 255, 255, 0.96) inset,
+    0 1px 3px rgba(16, 16, 28, 0.05),
+    0 8px 20px rgba(16, 16, 28, 0.06);
+  --shadow-card-hover:
+    0 1px 0 rgba(255, 255, 255, 0.98) inset,
+    0 2px 6px rgba(16, 16, 28, 0.06),
+    0 12px 28px rgba(16, 16, 28, 0.09);
+  font-family: 'Figtree', ui-sans-serif, system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
 }
 
 * {
@@ -21,182 +30,218 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg-gradient);
+  background: var(--page-bg);
   color: var(--text-primary);
   display: flex;
   justify-content: center;
-  padding: 48px 20px 72px;
+  padding: 10px 8px 28px;
 }
 
 @media (max-width: 640px) {
   body {
-    padding: 32px 16px 56px;
+    padding: 8px 6px 22px;
   }
 }
 
 .page-shell {
-  width: min(1080px, 100%);
+  width: min(1120px, 100%);
   display: grid;
-  gap: 48px;
+  gap: 14px;
 }
 
 .hero {
   display: grid;
-  gap: 12px;
+  gap: 4px;
   text-align: left;
 }
 
 .hero-eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(249, 245, 255, 0.7);
+  color: var(--text-subtle);
+}
+
+.hero-eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  background: var(--neon-lime);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--neon-lime) 70%, transparent);
 }
 
 .hero h1 {
   margin: 0;
-  font-size: clamp(2.6rem, 4vw + 1rem, 3.6rem);
-  font-family: 'Space Grotesk', 'Plus Jakarta Sans', sans-serif;
-  letter-spacing: -0.035em;
+  font-size: clamp(1.25rem, 2.6vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
 }
 
 .hero p {
   margin: 0;
-  font-size: 1.1rem;
-  line-height: 1.6;
+  font-size: 0.78rem;
+  line-height: 1.45;
   color: var(--text-subtle);
+  max-width: 48ch;
 }
 
 .app-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 28px;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
 }
 
 .app-card {
   position: relative;
   display: grid;
   grid-template-rows: auto auto 1fr auto;
-  gap: 12px;
-  padding: 28px 24px;
-  border-radius: 28px;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  padding: 8px 8px 6px;
+  min-height: 128px;
+  border-radius: 0;
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   text-decoration: none;
   color: inherit;
   overflow: hidden;
-  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
-}
-
-.app-card::before {
-  content: '';
-  position: absolute;
-  inset: -40% -20% 40% -20%;
-  background: radial-gradient(circle at top, color-mix(in srgb, var(--accent) 50%, transparent), transparent 60%);
-  opacity: 0;
-  transform: translateY(16px);
-  transition: opacity var(--transition), transform var(--transition);
+  box-shadow: var(--shadow-card);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
 }
 
 .app-card:hover,
 .app-card:focus-visible {
-  transform: translateY(-8px);
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--card-border));
-  box-shadow: 0 25px 60px -40px color-mix(in srgb, var(--accent) 60%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--card-border));
+  box-shadow:
+    var(--shadow-card-hover),
+    0 0 0 1px color-mix(in srgb, var(--neon-cyan) 28%, transparent);
 }
 
-.app-card:hover::before,
-.app-card:focus-visible::before {
-  opacity: 1;
-  transform: translateY(0px);
+.app-card:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--neon-magenta) 55%, var(--text-primary));
+  outline-offset: 2px;
 }
 
 .app-icon {
-  font-size: 2.6rem;
+  font-size: 1.35rem;
   display: inline-flex;
-  width: 64px;
-  height: 64px;
+  width: 36px;
+  height: 36px;
   align-items: center;
   justify-content: center;
-  border-radius: 20px;
-  background: color-mix(in srgb, var(--accent) 65%, rgba(255, 255, 255, 0.05));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--accent) 14%, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--card-border));
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.9) inset;
 }
 
 .app-title {
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 0.68rem;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
 }
 
 .app-blurb {
-  color: rgba(249, 245, 255, 0.72);
-  font-size: 0.98rem;
-  line-height: 1.5;
+  color: var(--text-subtle);
+  font-size: 0.58rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 .app-link {
-  font-weight: 600;
-  color: color-mix(in srgb, var(--accent) 65%, #ffffff);
+  justify-self: end;
+  align-self: end;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  margin-top: 2px;
+  font-size: 0;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--accent) 75%, var(--text-primary));
+  border: 1px solid var(--card-border);
+  background: color-mix(in srgb, var(--accent) 8%, #ffffff);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.95) inset;
+}
+
+.app-link::after {
+  content: '↗';
+  font-size: 0.85rem;
+  line-height: 1;
 }
 
 .about {
   display: flex;
-  justify-content: center;
+  justify-content: stretch;
 }
 
 .about-card {
-  max-width: 760px;
-  padding: 32px 36px;
-  border-radius: 30px;
-  background: rgba(15, 16, 32, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: var(--blur);
+  width: 100%;
+  max-width: none;
+  padding: 10px 12px;
+  border-radius: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-card);
   display: grid;
-  gap: 16px;
+  gap: 6px;
 }
 
 .about-card h2 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
 }
 
 .about-card p {
   margin: 0;
   color: var(--text-subtle);
-  line-height: 1.6;
+  font-size: 0.72rem;
+  line-height: 1.45;
 }
 
 .about-card .about-meta {
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text-primary);
+  font-size: 0.72rem;
 }
 
 .timeline {
   display: flex;
-  justify-content: center;
+  justify-content: stretch;
 }
 
 .timeline-card {
-  max-width: 760px;
-  padding: 32px 36px;
-  border-radius: 30px;
-  background: rgba(15, 16, 32, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: var(--blur);
+  width: 100%;
+  max-width: none;
+  padding: 10px 12px;
+  border-radius: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow-card);
   display: grid;
-  gap: 24px;
+  gap: 8px;
 }
 
 .timeline-card h2 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
 }
 
 .timeline-steps {
@@ -204,53 +249,56 @@ body {
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 18px;
+  gap: 6px;
 }
 
 .timeline-steps li {
   display: grid;
-  gap: 6px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 22px;
-  padding: 16px 20px;
+  gap: 2px;
+  background: #f6f6f9;
+  border: 1px solid var(--card-border);
+  border-left: 3px solid var(--neon-cyan);
+  border-radius: 0;
+  padding: 6px 8px;
 }
 
 .timeline-duration {
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  font-size: 0.78rem;
-  color: rgba(249, 245, 255, 0.75);
+  font-size: 0.58rem;
+  color: color-mix(in srgb, var(--neon-magenta) 55%, var(--text-subtle));
 }
 
 .timeline-description {
   color: var(--text-subtle);
-  line-height: 1.6;
+  font-size: 0.68rem;
+  line-height: 1.4;
 }
 
 .timeline-description a {
-  color: inherit;
+  color: var(--text-primary);
   text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-decoration-color: rgba(255, 255, 255, 0.4);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
 .timeline-total {
   margin: 0;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
+  font-size: 0.72rem;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   align-items: baseline;
 }
 
 .timeline-total-label {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-subtle);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-size: 0.78rem;
+  font-size: 0.58rem;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -164,10 +164,7 @@ body {
   color: rgba(20, 20, 26, 0.62);
   font-size: clamp(0.68rem, 2.2vw, 0.78rem);
   line-height: 1.35;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
-  overflow: hidden;
+  margin: 0;
 }
 
 .about {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -112,18 +112,22 @@ body {
   padding: 12px 10px 12px;
   min-height: 0;
   border-radius: 0;
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
+  background: color-mix(in srgb, var(--accent) 30%, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--accent) 48%, rgba(18, 18, 30, 0.12));
   text-decoration: none;
-  color: inherit;
+  color: var(--text-primary);
   overflow: hidden;
   box-shadow: var(--shadow-card);
-  transition: border-color 160ms ease, box-shadow 160ms ease;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
 }
 
 .app-card:hover,
 .app-card:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 38%, var(--card-border));
+  background: color-mix(in srgb, var(--accent) 38%, #ffffff);
+  border-color: color-mix(in srgb, var(--accent) 58%, rgba(18, 18, 30, 0.14));
   box-shadow:
     var(--shadow-card-hover),
     0 0 0 1px color-mix(in srgb, var(--neon-cyan) 28%, transparent);
@@ -143,9 +147,9 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 0;
-  background: color-mix(in srgb, var(--accent) 14%, #ffffff);
-  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--card-border));
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.9) inset;
+  background: rgba(255, 255, 255, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.75) inset;
 }
 
 .app-title {
@@ -156,7 +160,7 @@ body {
 }
 
 .app-blurb {
-  color: var(--text-subtle);
+  color: rgba(20, 20, 26, 0.62);
   font-size: clamp(0.68rem, 2.2vw, 0.78rem);
   line-height: 1.35;
   display: -webkit-box;
@@ -173,13 +177,13 @@ body {
 .about-card {
   width: 100%;
   max-width: none;
-  padding: 10px 12px;
+  padding: 12px 14px 14px;
   border-radius: 0;
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   box-shadow: var(--shadow-card);
   display: grid;
-  gap: 6px;
+  gap: 8px;
 }
 
 .about-card h2 {
@@ -204,30 +208,17 @@ body {
   font-size: 0.72rem;
 }
 
-.timeline {
-  display: flex;
-  justify-content: stretch;
-}
-
-.timeline-card {
-  width: 100%;
-  max-width: none;
-  padding: 10px 12px;
-  border-radius: 0;
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  box-shadow: var(--shadow-card);
-  display: grid;
-  gap: 8px;
-}
-
-.timeline-card h2 {
-  margin: 0;
+.about-subheading {
+  margin: 8px 0 0;
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--text-subtle);
+}
+
+.about-card .timeline-steps {
+  margin: 4px 0 0;
 }
 
 .timeline-steps {
@@ -267,6 +258,10 @@ body {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+}
+
+.about-card .timeline-total {
+  margin-top: 4px;
 }
 
 .timeline-total {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -91,18 +91,26 @@ body {
 
 .app-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
+}
+
+@media (min-width: 720px) {
+  .app-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 10px;
+  }
 }
 
 .app-card {
   position: relative;
   display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  grid-template-rows: auto auto 1fr;
   grid-template-columns: 1fr;
-  gap: 4px;
-  padding: 8px 8px 6px;
-  min-height: 128px;
+  align-content: start;
+  gap: 8px;
+  padding: 12px 10px 12px;
+  min-height: 0;
   border-radius: 0;
   background: var(--card-bg);
   border: 1px solid var(--card-border);
@@ -127,10 +135,11 @@ body {
 }
 
 .app-icon {
-  font-size: 1.35rem;
+  font-size: clamp(1.75rem, 6vw, 2.25rem);
+  line-height: 1;
   display: inline-flex;
-  width: 36px;
-  height: 36px;
+  width: clamp(44px, 14vw, 56px);
+  height: clamp(44px, 14vw, 56px);
   align-items: center;
   justify-content: center;
   border-radius: 0;
@@ -141,42 +150,19 @@ body {
 
 .app-title {
   font-weight: 700;
-  font-size: 0.68rem;
-  line-height: 1.25;
+  font-size: clamp(0.78rem, 2.8vw, 0.95rem);
+  line-height: 1.2;
   letter-spacing: -0.02em;
 }
 
 .app-blurb {
   color: var(--text-subtle);
-  font-size: 0.58rem;
+  font-size: clamp(0.68rem, 2.2vw, 0.78rem);
   line-height: 1.35;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 4;
   overflow: hidden;
-}
-
-.app-link {
-  justify-self: end;
-  align-self: end;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  margin-top: 2px;
-  font-size: 0;
-  font-weight: 600;
-  color: color-mix(in srgb, var(--accent) 75%, var(--text-primary));
-  border: 1px solid var(--card-border);
-  background: color-mix(in srgb, var(--accent) 8%, #ffffff);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.95) inset;
-}
-
-.app-link::after {
-  content: '↗';
-  font-size: 0.85rem;
-  line-height: 1;
 }
 
 .about {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Light hub + app shell with shared tokens; consistent **6px corner radius**, **short subtle stacked shadows** (`--shadow-raised` / `--shadow-deep`), and **light surfaces** across tools.

## Tokens (`src/styles/app-base.css`)

- `--radius: 6px` — apps use `border-radius: var(--radius, 6px)` after repo-wide sweep from square corners.
- Shadows reduced to thin inset highlight + 1–2 low-blur drops (no wide spreads).
- Back-link hover glow toned down.

## Hub (`src/styles/main.css`)

- Same `--radius` and softened `--shadow-card` / `--shadow-card-hover`.

## Apps

- **Bulk:** Heavy `box-shadow` patterns mapped to `var(--shadow-deep)` / `var(--shadow-raised)`; dark `rgba(0,0,0,…)` panel fills moved to light gray tints where appropriate.
- **Sokoban:** Full light vault (white/faint gray panels, blue wall tiles, frosted solved overlay, white inputs).
- **Audio spectrum:** Light toolbar/canvas/readouts; spectrum canvas on `#eef1f7` instead of near-black.
- **Camera filter lab:** White panels; preview shadows use theme tokens.
- **Piano:** Softer black-key gradient + mild shadow; panel uses `--shadow-deep`.
- **Palette maker / vibe-palette:** Panel borders fixed; chip/wheel/swatch shadows softened.

Filter texture overlays (scanlines, grain) may still use dark pixels for **effect**; chrome stays light.

## Verification

`npm run build` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69ae29e8-3ecb-47b3-aec4-34be35cbcfc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69ae29e8-3ecb-47b3-aec4-34be35cbcfc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

